### PR TITLE
Change the way of registering APIs in the scheme

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -20,17 +20,30 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
 var (
 	// GroupVersion is group version used to register these objects.
 	GroupVersion = schema.GroupVersion{Group: "infrastructure.cluster.x-k8s.io", Version: "v1alpha1"}
 
-	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
-	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
+	// schemeBuilder is used to add go types to the GroupVersionKind scheme.
+	schemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 
 	// AddToScheme adds the types in this group-version to the given scheme.
-	AddToScheme = SchemeBuilder.AddToScheme
+	AddToScheme = schemeBuilder.AddToScheme
+
+	// In order to reduce dependencies for API package consumers, CAPI has diverged from the default kubebuilder scheme builder.
+	// This new pattern may also be useful for reducing dependencies in provider API packages.
+	// For more information see the implementers guide.
+	// https://main.cluster-api.sigs.k8s.io/developer/providers/implementers-guide/create_api#registering-apis-in-the-scheme
+	objectTypes = []runtime.Object{}
 )
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(GroupVersion, objectTypes...)
+	metav1.AddToGroupVersion(scheme, GroupVersion)
+	return nil
+}

--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -85,7 +85,7 @@ type IonosCloudClusterList struct {
 }
 
 func init() {
-	SchemeBuilder.Register(&IonosCloudCluster{}, &IonosCloudClusterList{})
+	objectTypes = append(objectTypes, &IonosCloudCluster{}, &IonosCloudClusterList{})
 }
 
 // GetConditions returns the conditions from the status.

--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -248,5 +248,5 @@ func (m *IonosCloudMachine) SetConditions(conditions clusterv1.Conditions) {
 }
 
 func init() {
-	SchemeBuilder.Register(&IonosCloudMachine{}, &IonosCloudMachineList{})
+	objectTypes = append(objectTypes, &IonosCloudMachine{}, &IonosCloudMachineList{})
 }

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/errors"
 )


### PR DESCRIPTION
This PR:
- Change the registration of API in the schema as suggested in capi https://main.cluster-api.sigs.k8s.io/developer/providers/migrations/v1.5-to-v1.6#suggested-changes-for-providers