### PR TITLE
Ignore the tiltbuild directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ Dockerfile.cross
 
 !vendor/**/zz_generated.*
 
+# Tilt generated build directory
+.tiltbuild
+
 # env files should be ignored
 .env
 env


### PR DESCRIPTION
tilt creates an intermediate build folder and we should ignore it to not accidentally commit it