### PR TITLE
default empty value for cloud provider

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -151,7 +151,8 @@ spec:
     initConfiguration:
       nodeRegistration:
         kubeletExtraArgs:
-          cloud-provider: external
+          # use cloud-provider: external when using a CCM
+          cloud-provider: ""
     joinConfiguration:
       nodeRegistration:
         criSocket: unix:///run/containerd/containerd.sock
@@ -279,5 +280,6 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
-            cloud-provider: external
+            # use cloud-provider: external when using a CCM
+            cloud-provider: ""
           criSocket: unix:///run/containerd/containerd.sock


### PR DESCRIPTION
When not using a CCM, we need to make sure to not set the cloud-provider to external.
Setting it to external will cause the nodes to get a taint, which needs to be removed by a CCM.
Leaving it as empty string as default to not cause issues.
