### PR TITLE
:seedling: Simplify CSI metadata file

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -193,7 +193,6 @@ spec:
       # CSI Metadata config
       - content: |
           {
-            "node-id": "NODE_ID_PLACEHOLDER",
             "datacenter-id": "${IONOSCLOUD_DATACENTER_ID}"
           }
         owner: root:root
@@ -217,7 +216,6 @@ spec:
         kubectl --kubeconfig /etc/kubernetes/kubelet.conf
         patch node $(hostname)
         --type strategic -p '{"spec": {"providerID": "ionos://'$${system_uuid}'"}}'
-      - sed -i "s/NODE_ID_PLACEHOLDER/$(cat /sys/class/dmi/id/product_uuid)/g" /etc/ie-csi/cfg.json
     initConfiguration:
       localAPIEndpoint:
         bindPort: ${CONTROL_PLANE_ENDPOINT_PORT:-6443}
@@ -331,7 +329,6 @@ spec:
         # CSI Metadata config
         - content: |
             {
-              "node-id": "NODE_ID_PLACEHOLDER",
               "datacenter-id": "${IONOSCLOUD_DATACENTER_ID}"
             }
           owner: root:root
@@ -353,7 +350,6 @@ spec:
           kubectl --kubeconfig /etc/kubernetes/kubelet.conf
           patch node $(hostname)
           --type strategic -p '{"spec": {"providerID": "ionos://'$${system_uuid}'"}}'
-        - sed -i "s/NODE_ID_PLACEHOLDER/$(cat /sys/class/dmi/id/product_uuid)/g" /etc/ie-csi/cfg.json
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

The CSI no longer needs the `node-id` in its configuration file, but loads it on its own.

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)