### PR TITLE
:sparkles: Kube-vip uses admin.conf after kubeadm finished

### DIFF
--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -208,6 +208,9 @@ spec:
       - /etc/kube-vip-prepare.sh
     postKubeadmCommands:
       - >
+        sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' \
+        /etc/kubernetes/manifests/kube-vip.yaml
+      - >
         systemctl disable --now udisks2 multipathd motd-news.timer fwupd-refresh.timer
         packagekit ModemManager snapd snapd.socket snapd.apparmor snapd.seeded
       # TODO(jriedel-ionos): remove that if we have a CCM


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**
Changes the kubeconfig used by kube-vip back to admin.conf post kubeadm.

**Description of changes:**
- Adds call to change the kube-vip.yaml to postKubeadmCommands of cloud-init

**Special notes for your reviewer:**
* tested with k8s 1.29 (positiv /etc/kubernetes/manifests/kube-vip.yaml references admin.com)
* tested with k8s 1.28 (positiv /etc/kubernetes/manifests/kube-vip.yaml references admin.com)

**Checklist:**
- [X] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)