### PR TITLE
🌱 Revert removal of goimports in favour of gci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,12 +13,12 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - gci
     - ginkgolinter
     - goconst
     - gocritic
     - godot
     - gofumpt
+    - goimports
     - gosec
     - gosimple
     - govet
@@ -56,13 +56,8 @@ linters-settings:
         deny:
           - pkg: "github.com/pkg/errors"
             desc: Should be replaced by stdlib errors package
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/ionos-cloud/cluster-api-provider-ionoscloud)
-      - blank
-      - dot
+  goimports:
+    local-prefixes: github.com/ionos-cloud/cluster-api-provider-ionoscloud/
   gosec:
     excludes:
       - G601 # Implicit memory aliasing of items from a range statement: Obsolete since Go 1.22


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

Reverting the addition of the problematic gci with goimports. GCI keeps clashing with other linters, generating broken code.

**Issue #, if available:**

**Description of changes:**

Remove gci, come back with goimports

**Special notes for your reviewer:**

**Checklist:**
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)