### PR TITLE
:seedling: Prefix dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  commit-message:
+    prefix: ":seedling:"
   groups:
     kubernetes:
       patterns:
@@ -16,8 +18,12 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  commit-message:
+    prefix: ":seedling:"
 
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
     interval: "daily"
+  commit-message:
+    prefix: ":seedling:"


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

**Issue #, if available:**

**Description of changes:**

Configure dependabot to prefix commit messages with `:seedling:`.

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
