### PR TITLE
:seedling: Add short name and categories to CRD

### DIFF
--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -84,7 +84,7 @@ type IonosCloudClusterStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:path=ionoscloudclusters,scope=Namespaced,categories=cluster-api;ionos,shortName=icc
+//+kubebuilder:resource:path=ionoscloudclusters,scope=Namespaced,categories=cluster-api;ionoscloud,shortName=icc
 //+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Cluster infrastructure is ready"
 //+kubebuilder:printcolumn:name="Endpoint",type="string",JSONPath=".spec.controlPlaneEndpoint",description="API Endpoint"

--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -281,7 +281,7 @@ type NICInfo struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-//+kubebuilder:resource:path=ionoscloudmachines,scope=Namespaced,categories=cluster-api;ionos,shortName=icm
+//+kubebuilder:resource:path=ionoscloudmachines,scope=Namespaced,categories=cluster-api;ionoscloud,shortName=icm
 //+kubebuilder:printcolumn:name="Cluster",type="string",JSONPath=".metadata.labels['cluster\\.x-k8s\\.io/cluster-name']",description="Cluster"
 //+kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.ready",description="Machine is ready"
 //+kubebuilder:printcolumn:name="IPv4 Addresses",type="string",JSONPath=".status.machineNetworkInfo.nicInfo[*].ipv4Addresses"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - cluster-api
-    - ionos
+    - ionoscloud
     kind: IonosCloudCluster
     listKind: IonosCloudClusterList
     plural: ionoscloudclusters

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachines.yaml
@@ -10,7 +10,7 @@ spec:
   names:
     categories:
     - cluster-api
-    - ionos
+    - ionoscloud
     kind: IonosCloudMachine
     listKind: IonosCloudMachineList
     plural: ionoscloudmachines


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

**Issue #, if available:**

**Description of changes:**

```
kubectl get icc         # Show IonosCloudClusters
kubectl get icm         # Show IonosCloudMachines
kubectl get cluster-api # Now includes ionoscloud resources
kubectl get ionoscloud  # Show ionoscloud resources
```

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
