### PR TITLE
:warning: Request for comments: FailoverIPs for machinedeployments

### DIFF
--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -140,15 +140,15 @@ type IonosCloudMachineSpec struct {
 	//+optional
 	AdditionalNetworks Networks `json:"additionalNetworks,omitempty"`
 
-	// FailoverIP can be set to enable failover for VMs in the same MachineDeployment.
-	// It can be either set to an already reserved IPv4 address, or it can be set to "AUTO"
+	// FailoverIPs can be set to enable failover for VMs in the same MachineDeployment.
+	// The entries can be either set to an already reserved IPv4 address, or it can be set to "AUTO"
 	// which will automatically reserve an IPv4 address for the Failover Group.
 	//
 	// If the machine is a control plane machine, this field will not be taken into account.
-	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="failoverIP is immutable"
-	//+kubebuilder:validation:XValidation:rule=`self == "AUTO" || self.matches("((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$")`,message="failoverIP must be either 'AUTO' or a valid IPv4 address"
+	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="failoverIPs is immutable"
+	//+kubebuilder:validation:XValidation:rule=`self.all(ip, ip == "AUTO" || ip.matches("((25[0-5]|(2[0-4]|1\\d|[1-9]|)\\d)\\.?\\b){4}$"))`,message="failoverIPs entries must be either 'AUTO' or a valid IPv4 address"
 	//+optional
-	FailoverIP *string `json:"failoverIP,omitempty"`
+	FailoverIPs []string `json:"failoverIPs,omitempty"`
 }
 
 // Networks contains a list of additional LAN IDs


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**
We are using Metallb (https://metallb.universe.tf/) to announce public IPv4 addresses for our services of type LoadBalancer. Therefore we need the possibility to assign multiple FailoverIPs to an IonosCloudMachine.

As there is already the possibility to assign a single FailoverIP on an IonosCloudMachine I'd propose to make the field a list as outlined in this PR.

Please let me know if you are okay with this api change. I'd then start working on this.

