### PR TITLE
:sparkles: Make `MaxConcurrentReconciles` configurable

### DIFF
--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"sync"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -33,6 +35,10 @@ const (
 	// IonosCloudClusterKind is the string resource kind of the IonosCloudCluster resource.
 	IonosCloudClusterKind = "IonosCloudCluster"
 )
+
+// currentRequestByDatacenterMutex is used to synchronize access to the
+// IonosCloudCluster.Status.CurrentRequestByDatacenter map.
+var currentRequestByDatacenterMutex sync.RWMutex
 
 // IonosCloudClusterSpec defines the desired state of IonosCloudCluster.
 type IonosCloudClusterSpec struct {
@@ -66,6 +72,7 @@ type IonosCloudClusterStatus struct {
 	Conditions clusterv1.Conditions `json:"conditions,omitempty"`
 
 	// CurrentRequestByDatacenter maps data center IDs to a pending provisioning request made during reconciliation.
+	// Use the provided getters and setters to access and modify this map to ensure thread safety.
 	//+optional
 	CurrentRequestByDatacenter map[string]ProvisioningRequest `json:"currentRequest,omitempty"`
 
@@ -117,9 +124,20 @@ func (i *IonosCloudCluster) SetConditions(conditions clusterv1.Conditions) {
 	i.Status.Conditions = conditions
 }
 
+// GetCurrentRequestByDatacenter returns the current provisioning request for the given data center and a boolean
+// indicating if it exists.
+func (i *IonosCloudCluster) GetCurrentRequestByDatacenter(datacenterID string) (ProvisioningRequest, bool) {
+	currentRequestByDatacenterMutex.RLock()
+	defer currentRequestByDatacenterMutex.RUnlock()
+	req, ok := i.Status.CurrentRequestByDatacenter[datacenterID]
+	return req, ok
+}
+
 // SetCurrentRequestByDatacenter sets the current provisioning request for the given data center.
 // This function makes sure that the map is initialized before setting the request.
 func (i *IonosCloudCluster) SetCurrentRequestByDatacenter(datacenterID, method, status, requestPath string) {
+	currentRequestByDatacenterMutex.Lock()
+	defer currentRequestByDatacenterMutex.Unlock()
 	if i.Status.CurrentRequestByDatacenter == nil {
 		i.Status.CurrentRequestByDatacenter = map[string]ProvisioningRequest{}
 	}
@@ -132,6 +150,8 @@ func (i *IonosCloudCluster) SetCurrentRequestByDatacenter(datacenterID, method, 
 
 // DeleteCurrentRequestByDatacenter deletes the current provisioning request for the given data center.
 func (i *IonosCloudCluster) DeleteCurrentRequestByDatacenter(datacenterID string) {
+	currentRequestByDatacenterMutex.Lock()
+	defer currentRequestByDatacenterMutex.Unlock()
 	delete(i.Status.CurrentRequestByDatacenter, datacenterID)
 }
 

--- a/api/v1alpha1/ionoscloudcluster_types_test.go
+++ b/api/v1alpha1/ionoscloudcluster_types_test.go
@@ -148,7 +148,9 @@ var _ = Describe("IonosCloudCluster", func() {
 				RequestPath: "/path/to/resource",
 				State:       "QUEUED",
 			}
-			fetched.Status.CurrentRequestByDatacenter["123"] = wantProvisionRequest
+			fetched.Status.CurrentRequestByDatacenter = map[string]ProvisioningRequest{
+				"123": wantProvisionRequest,
+			}
 			conditions.MarkTrue(fetched, clusterv1.ReadyCondition)
 
 			By("updating the cluster status")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,7 +90,7 @@ func main() {
 
 	ctx := ctrl.SetupSignalHandler()
 
-	if err = iccontroller.RegisterIonosCloudClusterReconciler(
+	if err = iccontroller.NewIonosCloudClusterReconciler(mgr).SetupWithManager(
 		ctx,
 		mgr,
 		controller.Options{MaxConcurrentReconciles: icClusterConcurrency},
@@ -98,7 +98,7 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "IonosCloudCluster")
 		os.Exit(1)
 	}
-	if err = iccontroller.RegisterIonosCloudMachineReconciler(
+	if err = iccontroller.NewIonosCloudMachineReconciler(mgr).SetupWithManager(
 		mgr,
 		controller.Options{MaxConcurrentReconciles: icMachineConcurrency},
 	); err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -133,8 +133,8 @@ func initFlags() {
 	pflag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	pflag.IntVar(&icClusterConcurrency, "ionoscloud-cluster-concurrency", 1,
+	pflag.IntVar(&icClusterConcurrency, "ionoscloudcluster-concurrency", 1,
 		"Number of IonosCloudClusters to process simultaneously")
-	pflag.IntVar(&icMachineConcurrency, "ionoscloud-machine-concurrency", 1,
+	pflag.IntVar(&icMachineConcurrency, "ionoscloudmachine-concurrency", 1,
 		"Number of IonosCloudMachines to process simultaneously")
 }

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -209,9 +209,8 @@ spec:
                   - method
                   - requestPath
                   type: object
-                description: |-
-                  CurrentRequestByDatacenter maps data center IDs to a pending provisioning request made during reconciliation.
-                  Use the provided getters and setters to access and modify this map to ensure thread safety.
+                description: CurrentRequestByDatacenter maps data center IDs to a
+                  pending provisioning request made during reconciliation.
                 type: object
               ready:
                 description: Ready indicates that the cluster is ready.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -209,8 +209,9 @@ spec:
                   - method
                   - requestPath
                   type: object
-                description: CurrentRequestByDatacenter maps data center IDs to a
-                  pending provisioning request made during reconciliation.
+                description: |-
+                  CurrentRequestByDatacenter maps data center IDs to a pending provisioning request made during reconciliation.
+                  Use the provided getters and setters to access and modify this map to ensure thread safety.
                 type: object
               ready:
                 description: Ready indicates that the cluster is ready.

--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -52,6 +52,7 @@ type IonosCloudClusterReconciler struct {
 	locker *locker.Locker
 }
 
+// NewIonosCloudClusterReconciler creates a new IonosCloudClusterReconciler.
 func NewIonosCloudClusterReconciler(mgr ctrl.Manager) *IonosCloudClusterReconciler {
 	r := &IonosCloudClusterReconciler{
 		Client: mgr.GetClient(),

--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -108,6 +108,7 @@ func (r *ionosCloudClusterReconciler) Reconcile(
 		Client:       r.Client,
 		Cluster:      cluster,
 		IonosCluster: ionosCloudCluster,
+		Locker:       r.locker,
 	})
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("unable to create scope %w", err)

--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -41,6 +41,7 @@ import (
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-ionoscloud/api/v1alpha1"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/service/cloud"
+	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/locker"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/scope"
 )
 
@@ -48,6 +49,7 @@ import (
 type ionosCloudClusterReconciler struct {
 	client.Client
 	scheme *runtime.Scheme
+	locker *locker.Locker
 }
 
 // RegisterIonosCloudClusterReconciler creates an ionosCloudClusterReconciler and registers it with the manager.
@@ -63,6 +65,7 @@ func newIonosCloudClusterReconciler(mgr ctrl.Manager) *ionosCloudClusterReconcil
 	r := &ionosCloudClusterReconciler{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
+		locker: locker.New(),
 	}
 	return r
 }

--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -45,24 +45,15 @@ import (
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/scope"
 )
 
-// ionosCloudClusterReconciler reconciles a IonosCloudCluster object.
-type ionosCloudClusterReconciler struct {
+// IonosCloudClusterReconciler reconciles a IonosCloudCluster object.
+type IonosCloudClusterReconciler struct {
 	client.Client
 	scheme *runtime.Scheme
 	locker *locker.Locker
 }
 
-// RegisterIonosCloudClusterReconciler creates an ionosCloudClusterReconciler and registers it with the manager.
-func RegisterIonosCloudClusterReconciler(
-	ctx context.Context,
-	mgr ctrl.Manager,
-	options controller.Options,
-) error {
-	return newIonosCloudClusterReconciler(mgr).setupWithManager(ctx, mgr, options)
-}
-
-func newIonosCloudClusterReconciler(mgr ctrl.Manager) *ionosCloudClusterReconciler {
-	r := &ionosCloudClusterReconciler{
+func NewIonosCloudClusterReconciler(mgr ctrl.Manager) *IonosCloudClusterReconciler {
+	r := &IonosCloudClusterReconciler{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
 		locker: locker.New(),
@@ -83,7 +74,7 @@ func newIonosCloudClusterReconciler(mgr ctrl.Manager) *ionosCloudClusterReconcil
 //
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.0/pkg/reconcile
-func (r *ionosCloudClusterReconciler) Reconcile(
+func (r *IonosCloudClusterReconciler) Reconcile(
 	ctx context.Context,
 	ionosCloudCluster *infrav1.IonosCloudCluster,
 ) (_ ctrl.Result, retErr error) {
@@ -138,7 +129,7 @@ func (r *ionosCloudClusterReconciler) Reconcile(
 	return r.reconcileNormal(ctx, clusterScope, cloudService)
 }
 
-func (r *ionosCloudClusterReconciler) reconcileNormal(
+func (r *IonosCloudClusterReconciler) reconcileNormal(
 	ctx context.Context,
 	clusterScope *scope.Cluster,
 	cloudService *cloud.Service,
@@ -175,7 +166,7 @@ func (r *ionosCloudClusterReconciler) reconcileNormal(
 	return ctrl.Result{}, nil
 }
 
-func (r *ionosCloudClusterReconciler) reconcileDelete(
+func (r *IonosCloudClusterReconciler) reconcileDelete(
 	ctx context.Context, clusterScope *scope.Cluster, cloudService *cloud.Service,
 ) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -224,7 +215,7 @@ func (r *ionosCloudClusterReconciler) reconcileDelete(
 	return ctrl.Result{}, nil
 }
 
-func (*ionosCloudClusterReconciler) checkRequestStatus(
+func (*IonosCloudClusterReconciler) checkRequestStatus(
 	ctx context.Context, clusterScope *scope.Cluster, cloudService *cloud.Service,
 ) (requeue bool, retErr error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -245,8 +236,8 @@ func (*ionosCloudClusterReconciler) checkRequestStatus(
 	return requeue, retErr
 }
 
-// setupWithManager sets up the controller with the Manager.
-func (r *ionosCloudClusterReconciler) setupWithManager(
+// SetupWithManager sets up the controller with the Manager.
+func (r *IonosCloudClusterReconciler) SetupWithManager(
 	ctx context.Context,
 	mgr ctrl.Manager,
 	options controller.Options,

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -259,9 +259,9 @@ func (*ionosCloudMachineReconciler) checkRequestStates(
 	cloudService *cloud.Service,
 ) (requeue bool, retErr error) {
 	log := ctrl.LoggerFrom(ctx)
-	// check cluster wide request
+	// check cluster-wide request
 	ionosCluster := machineScope.ClusterScope.IonosCluster
-	if req, exists := ionosCluster.Status.CurrentRequestByDatacenter[machineScope.DatacenterID()]; exists {
+	if req, exists := ionosCluster.GetCurrentRequestByDatacenter(machineScope.DatacenterID()); exists {
 		status, message, err := cloudService.GetRequestStatus(ctx, req.RequestPath)
 		if err != nil {
 			retErr = fmt.Errorf("could not get request status: %w", err)

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -40,20 +40,15 @@ import (
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/scope"
 )
 
-// ionosCloudMachineReconciler reconciles a IonosCloudMachine object.
-type ionosCloudMachineReconciler struct {
+// IonosCloudMachineReconciler reconciles a IonosCloudMachine object.
+type IonosCloudMachineReconciler struct {
 	client.Client
 	scheme *runtime.Scheme
 	locker *locker.Locker
 }
 
-// RegisterIonosCloudMachineReconciler creates an ionosCloudMachineReconciler and registers it with the manager.
-func RegisterIonosCloudMachineReconciler(mgr ctrl.Manager, options controller.Options) error {
-	return newIonosCloudMachineReconciler(mgr).setupWithManager(mgr, options)
-}
-
-func newIonosCloudMachineReconciler(mgr ctrl.Manager) *ionosCloudMachineReconciler {
-	r := &ionosCloudMachineReconciler{
+func NewIonosCloudMachineReconciler(mgr ctrl.Manager) *IonosCloudMachineReconciler {
+	r := &IonosCloudMachineReconciler{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
 		locker: locker.New(),
@@ -69,7 +64,7 @@ func newIonosCloudMachineReconciler(mgr ctrl.Manager) *ionosCloudMachineReconcil
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 
-func (r *ionosCloudMachineReconciler) Reconcile(
+func (r *IonosCloudMachineReconciler) Reconcile(
 	ctx context.Context,
 	ionosCloudMachine *infrav1.IonosCloudMachine,
 ) (_ ctrl.Result, retErr error) {
@@ -145,7 +140,7 @@ func (r *ionosCloudMachineReconciler) Reconcile(
 	return r.reconcileNormal(ctx, cloudService, machineScope)
 }
 
-func (r *ionosCloudMachineReconciler) reconcileNormal(
+func (r *IonosCloudMachineReconciler) reconcileNormal(
 	ctx context.Context, cloudService *cloud.Service, machineScope *scope.Machine,
 ) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -202,7 +197,7 @@ func (r *ionosCloudMachineReconciler) reconcileNormal(
 	return ctrl.Result{}, nil
 }
 
-func (r *ionosCloudMachineReconciler) reconcileDelete(
+func (r *IonosCloudMachineReconciler) reconcileDelete(
 	ctx context.Context, machineScope *scope.Machine, cloudService *cloud.Service,
 ) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
@@ -253,7 +248,7 @@ func (r *ionosCloudMachineReconciler) reconcileDelete(
 //   - Queued, Running => Requeue the current request
 //   - Failed => Log the error and continue also apply the same logic as in Done.
 //   - Done => Clear request from the status and continue reconciliation.
-func (*ionosCloudMachineReconciler) checkRequestStates(
+func (*IonosCloudMachineReconciler) checkRequestStates(
 	ctx context.Context,
 	machineScope *scope.Machine,
 	cloudService *cloud.Service,
@@ -296,7 +291,7 @@ func (*ionosCloudMachineReconciler) checkRequestStates(
 	return requeue, retErr
 }
 
-func (*ionosCloudMachineReconciler) isInfrastructureReady(ctx context.Context, ms *scope.Machine) bool {
+func (*IonosCloudMachineReconciler) isInfrastructureReady(ctx context.Context, ms *scope.Machine) bool {
 	log := ctrl.LoggerFrom(ctx)
 	// Make sure the infrastructure is ready.
 	if !ms.ClusterScope.Cluster.Status.InfrastructureReady {
@@ -326,8 +321,8 @@ func (*ionosCloudMachineReconciler) isInfrastructureReady(ctx context.Context, m
 	return true
 }
 
-// setupWithManager sets up the controller with the Manager.
-func (r *ionosCloudMachineReconciler) setupWithManager(mgr ctrl.Manager, options controller.Options) error {
+// SetupWithManager sets up the controller with the Manager.
+func (r *IonosCloudMachineReconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
 		For(&infrav1.IonosCloudMachine{}).
@@ -338,7 +333,7 @@ func (r *ionosCloudMachineReconciler) setupWithManager(mgr ctrl.Manager, options
 		Complete(reconcile.AsReconciler[*infrav1.IonosCloudMachine](r.Client, r))
 }
 
-func (r *ionosCloudMachineReconciler) getClusterScope(
+func (r *IonosCloudMachineReconciler) getClusterScope(
 	ctx context.Context, cluster *clusterv1.Cluster, ionosCloudMachine *infrav1.IonosCloudMachine,
 ) (*scope.Cluster, error) {
 	var clusterScope *scope.Cluster

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -366,6 +366,7 @@ func (r *ionosCloudMachineReconciler) getClusterScope(
 		Client:       r.Client,
 		Cluster:      cluster,
 		IonosCluster: ionosCloudCluster,
+		Locker:       r.locker,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cluster scope: %w", err)

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -47,6 +47,7 @@ type IonosCloudMachineReconciler struct {
 	locker *locker.Locker
 }
 
+// NewIonosCloudMachineReconciler creates a new IonosCloudMachineReconciler.
 func NewIonosCloudMachineReconciler(mgr ctrl.Manager) *IonosCloudMachineReconciler {
 	r := &IonosCloudMachineReconciler{
 		Client: mgr.GetClient(),

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -260,8 +260,7 @@ func (*ionosCloudMachineReconciler) checkRequestStates(
 ) (requeue bool, retErr error) {
 	log := ctrl.LoggerFrom(ctx)
 	// check cluster-wide request
-	ionosCluster := machineScope.ClusterScope.IonosCluster
-	if req, exists := ionosCluster.GetCurrentRequestByDatacenter(machineScope.DatacenterID()); exists {
+	if req, exists := machineScope.ClusterScope.GetCurrentRequestByDatacenter(machineScope.DatacenterID()); exists {
 		status, message, err := cloudService.GetRequestStatus(ctx, req.RequestPath)
 		if err != nil {
 			retErr = fmt.Errorf("could not get request status: %w", err)
@@ -269,7 +268,7 @@ func (*ionosCloudMachineReconciler) checkRequestStates(
 			requeue, retErr = withStatus(status, message, &log,
 				func() error {
 					// remove the request from the status and patch the cluster
-					ionosCluster.DeleteCurrentRequestByDatacenter(machineScope.DatacenterID())
+					machineScope.ClusterScope.DeleteCurrentRequestByDatacenter(machineScope.DatacenterID())
 					return machineScope.ClusterScope.PatchObject()
 				},
 			)

--- a/internal/service/cloud/ipblock_test.go
+++ b/internal/service/cloud/ipblock_test.go
@@ -487,6 +487,10 @@ func (s *ipBlockTestSuite) buildRequest(status string, method, id string) sdk.Re
 	return s.buildIPBlockRequestWithName(s.service.controlPlaneEndpointIPBlockName(s.clusterScope), status, method, id)
 }
 
+func (s *ipBlockTestSuite) TestFailoverIPBlockLockKey() {
+	s.Equal("fo-ipb/default/test-md", s.service.failoverIPBlockLockKey(s.machineScope))
+}
+
 // exampleIPBlock returns a new sdk.IpBlock instance for testing. The IPs need to be set.
 func exampleIPBlock() *sdk.IpBlock {
 	return exampleIPBlockWithName(exampleIPBlockName)

--- a/internal/service/cloud/network.go
+++ b/internal/service/cloud/network.go
@@ -46,7 +46,9 @@ func (*Service) lanLockKey(ms *scope.Machine) string {
 	// LANs are shared across machines within a datacenter, so need to be locked when performing write operations during
 	// concurrent machine reconciliations.
 	// Their datacenter scope fits well to be part of the key used for locking the LAN.
-	return "dc/" + ms.DatacenterID() + "/lan"
+	// To not interfere with other clusters having resources in the same datacenter, the cluster is also part of the
+	// key.
+	return "cluster/" + string(ms.ClusterScope.Cluster.UID) + "/dc/" + ms.DatacenterID() + "/lan"
 }
 
 func (*Service) lanURL(datacenterID, id string) string {

--- a/internal/service/cloud/network.go
+++ b/internal/service/cloud/network.go
@@ -191,7 +191,7 @@ func (s *Service) createLAN(ctx context.Context, ms *scope.Machine) error {
 		return fmt.Errorf("unable to create LAN in data center %s: %w", ms.DatacenterID(), err)
 	}
 
-	ms.ClusterScope.IonosCluster.SetCurrentRequestByDatacenter(ms.DatacenterID(),
+	ms.ClusterScope.SetCurrentRequestByDatacenter(ms.DatacenterID(),
 		http.MethodPost, sdk.RequestStatusQueued, requestPath)
 
 	err = ms.ClusterScope.PatchObject()
@@ -212,7 +212,7 @@ func (s *Service) deleteLAN(ctx context.Context, ms *scope.Machine, lanID string
 		return fmt.Errorf("unable to request LAN deletion in data center: %w", err)
 	}
 
-	ms.ClusterScope.IonosCluster.SetCurrentRequestByDatacenter(ms.DatacenterID(),
+	ms.ClusterScope.SetCurrentRequestByDatacenter(ms.DatacenterID(),
 		http.MethodDelete, sdk.RequestStatusQueued, requestPath)
 
 	err = ms.ClusterScope.PatchObject()
@@ -254,7 +254,7 @@ func (s *Service) getLatestLANPatchRequest(ctx context.Context, ms *scope.Machin
 }
 
 func (*Service) removeLANPendingRequestFromCluster(ms *scope.Machine) error {
-	ms.ClusterScope.IonosCluster.DeleteCurrentRequestByDatacenter(ms.DatacenterID())
+	ms.ClusterScope.DeleteCurrentRequestByDatacenter(ms.DatacenterID())
 	if err := ms.ClusterScope.PatchObject(); err != nil {
 		return fmt.Errorf("could not remove stale LAN pending request from cluster: %w", err)
 	}

--- a/internal/service/cloud/network_test.go
+++ b/internal/service/cloud/network_test.go
@@ -50,6 +50,10 @@ func (s *lanSuite) TestNetworkLANName() {
 	s.Equal("lan-default-test-cluster", s.service.lanName(s.clusterScope.Cluster))
 }
 
+func (s *lanSuite) TestLANLockKey() {
+	s.Equal("cluster/uid/dc/ccf27092-34e8-499e-a2f5-2bdee9d34a12/lan", s.service.lanLockKey(s.machineScope))
+}
+
 func (s *lanSuite) TestLANURL() {
 	s.Equal("datacenters/"+s.machineScope.DatacenterID()+"/lans/1",
 		s.service.lanURL(s.machineScope.DatacenterID(), "1"))

--- a/internal/service/cloud/network_test.go
+++ b/internal/service/cloud/network_test.go
@@ -62,7 +62,7 @@ func (s *lanSuite) TestLANURLs() {
 func (s *lanSuite) TestNetworkCreateLANSuccessful() {
 	s.mockCreateLANCall().Return(exampleRequestPath, nil).Once()
 	s.NoError(s.service.createLAN(s.ctx, s.machineScope))
-	req, exists := s.infraCluster.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
+	req, exists := s.clusterScope.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
 	s.True(exists, "request should be stored in status")
 	s.Equal(exampleRequestPath, req.RequestPath, "request path should be stored in status")
 	s.Equal(http.MethodPost, req.Method, "request method should be stored in status")
@@ -72,7 +72,7 @@ func (s *lanSuite) TestNetworkCreateLANSuccessful() {
 func (s *lanSuite) TestNetworkDeleteLANSuccessful() {
 	s.mockDeleteLANCall(exampleLANID).Return(exampleRequestPath, nil).Once()
 	s.NoError(s.service.deleteLAN(s.ctx, s.machineScope, exampleLANID))
-	req, exists := s.infraCluster.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
+	req, exists := s.clusterScope.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
 	s.True(exists, "request should be stored in status")
 	s.Equal(exampleRequestPath, req.RequestPath, "request path should be stored in status")
 	s.Equal(http.MethodDelete, req.Method, "request method should be stored in status")
@@ -103,10 +103,10 @@ func (s *lanSuite) TestNetworkGetLANErrorNotUnique() {
 }
 
 func (s *lanSuite) TestNetworkRemoveLANPendingRequestFromClusterSuccessful() {
-	s.infraCluster.SetCurrentRequestByDatacenter(s.machineScope.DatacenterID(), http.MethodDelete, sdk.RequestStatusQueued,
+	s.clusterScope.SetCurrentRequestByDatacenter(s.machineScope.DatacenterID(), http.MethodDelete, sdk.RequestStatusQueued,
 		exampleRequestPath)
 	s.NoError(s.service.removeLANPendingRequestFromCluster(s.machineScope))
-	_, exists := s.infraCluster.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
+	_, exists := s.clusterScope.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
 	s.False(exists, "request should be removed from status")
 }
 
@@ -164,7 +164,7 @@ func (s *lanSuite) TestNetworkReconcileLANDeleteLANExistsNoPendingRequestsHasOth
 	requeue, err := s.service.ReconcileLANDeletion(s.ctx, s.machineScope)
 	s.NoError(err)
 	s.False(requeue)
-	_, exists := s.infraCluster.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
+	_, exists := s.clusterScope.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
 	s.False(exists)
 }
 
@@ -191,7 +191,7 @@ func (s *lanSuite) TestNetworkReconcileLANDeleteLANDoesNotExist() {
 	requeue, err := s.service.ReconcileLANDeletion(s.ctx, s.machineScope)
 	s.NoError(err)
 	s.False(requeue)
-	_, exists := s.infraCluster.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
+	_, exists := s.clusterScope.GetCurrentRequestByDatacenter(s.machineScope.DatacenterID())
 	s.False(exists)
 }
 

--- a/internal/service/cloud/suite_test.go
+++ b/internal/service/cloud/suite_test.go
@@ -36,6 +36,7 @@ import (
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-ionoscloud/api/v1alpha1"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/ionoscloud/clienttest"
+	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/locker"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/ptr"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/scope"
 )
@@ -189,6 +190,7 @@ func (s *ServiceTestSuite) SetupTest() {
 		Machine:      s.capiMachine,
 		ClusterScope: s.clusterScope,
 		IonosMachine: s.infraMachine,
+		Locker:       locker.New(),
 	})
 	s.NoError(err, "failed to create machine scope")
 

--- a/internal/service/cloud/suite_test.go
+++ b/internal/service/cloud/suite_test.go
@@ -182,6 +182,7 @@ func (s *ServiceTestSuite) SetupTest() {
 		Client:       s.k8sClient,
 		Cluster:      s.capiCluster,
 		IonosCluster: s.infraCluster,
+		Locker:       locker.New(),
 	})
 	s.NoError(err, "failed to create cluster scope")
 

--- a/internal/service/cloud/suite_test.go
+++ b/internal/service/cloud/suite_test.go
@@ -108,6 +108,7 @@ func (s *ServiceTestSuite) SetupTest() {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: metav1.NamespaceDefault,
 			Name:      "test-cluster",
+			UID:       "uid",
 		},
 		Spec: clusterv1.ClusterSpec{},
 	}
@@ -143,7 +144,8 @@ func (s *ServiceTestSuite) SetupTest() {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "test-machine",
 			Labels: map[string]string{
-				clusterv1.ClusterNameLabel: s.capiCluster.Name,
+				clusterv1.ClusterNameLabel:           s.capiCluster.Name,
+				clusterv1.MachineDeploymentNameLabel: "test-md",
 			},
 		},
 		Spec: infrav1.IonosCloudMachineSpec{

--- a/internal/util/locker/locker.go
+++ b/internal/util/locker/locker.go
@@ -77,6 +77,7 @@ func (lwc *lockWithCounter) count() int32 {
 }
 
 // Lock locks the given key. Returns after acquiring lock or when given context is done.
+// The only errors it can return stem from the context being done.
 func (l *Locker) Lock(ctx context.Context, key string) error {
 	l.mu.Lock()
 

--- a/internal/util/locker/locker.go
+++ b/internal/util/locker/locker.go
@@ -1,0 +1,123 @@
+/*
+Package locker provides a mechanism for fine-grained locking.
+
+In contrast to a sync.Mutex, the user must provide a key when locking and unlocking.
+
+If a lock with a given key does not exist when Lock() is called, one is created.
+Lock references are automatically cleaned up if nothing is waiting for the lock anymore.
+
+Locking can be aborted on context cancellation.
+
+This package is inspired by https://github.com/moby/locker, but uses a buffered channel instead of a sync.Mutex to allow
+for context cancellation.
+Even though the standard library does not offer to cancel locking a mutex, golang.org/x/sync/semaphore does for its
+Acquire() method.
+*/
+package locker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+)
+
+// Locker offers thread-safe locking of entities represented by keys of type string.
+type Locker struct {
+	mu    sync.Mutex // protects the locks map
+	locks map[string]*lockWithCounter
+}
+
+// New returns a new Locker.
+func New() *Locker {
+	locker := &Locker{
+		locks: make(map[string]*lockWithCounter),
+	}
+	return locker
+}
+
+// lockWithCounter is used by Locker to represent a lock for a given key.
+type lockWithCounter struct {
+	// ch is a buffered channel of size 1 used as a mutex.
+	// In contrast to a sync.Mutex, accessing the channel can be aborted upon context cancellation.
+	ch chan struct{}
+	// waiters is the number of callers waiting to acquire the lock.
+	// This is Int32 instead of Uint32, so we can add -1 in dec().
+	waiters atomic.Int32
+}
+
+// inc increments the number of waiters.
+func (lwc *lockWithCounter) inc() {
+	lwc.waiters.Add(1)
+}
+
+// dec decrements the number of waiters.
+func (lwc *lockWithCounter) dec() {
+	lwc.waiters.Add(-1)
+}
+
+// count gets the current number of waiters.
+func (lwc *lockWithCounter) count() int32 {
+	return lwc.waiters.Load()
+}
+
+// Lock locks the given key. Returns after acquiring lock or when given context is done.
+func (l *Locker) Lock(ctx context.Context, key string) error {
+	l.mu.Lock()
+
+	select {
+	case <-ctx.Done():
+		// ctx becoming done has "happened before" acquiring the lock, whether it became done before the call began or
+		// while we were waiting for the mutex. We prefer to fail even if we could acquire the mutex without blocking.
+		l.mu.Unlock()
+		return ctx.Err()
+	default:
+	}
+
+	lwc, exists := l.locks[key]
+	if !exists {
+		lwc = &lockWithCounter{
+			ch: make(chan struct{}, 1),
+		}
+		l.locks[key] = lwc
+	}
+	// Increment the waiters while inside the mutex to make sure that the lock isn't deleted if Lock() and Unlock()
+	// are called concurrently.
+	lwc.inc()
+
+	l.mu.Unlock()
+
+	// Lock the key outside the mutex, so we don't block other operations.
+	select {
+	case lwc.ch <- struct{}{}:
+		// Lock acquired, so we can decrement the number of waiters for this lock.
+		lwc.dec()
+		return nil
+	case <-ctx.Done():
+		// Locking aborted, so we can decrement the number of waiters for this lock.
+		lwc.dec()
+		// If there are no more waiters, we can delete the lock.
+		l.mu.Lock()
+		if lwc.count() == 0 {
+			delete(l.locks, key)
+		}
+		l.mu.Unlock()
+
+		return ctx.Err()
+	}
+}
+
+// Unlock unlocks the given key. It panics if the key is not locked.
+func (l *Locker) Unlock(key string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	lwc, exists := l.locks[key]
+	if !exists {
+		panic("no such lock: " + key)
+	}
+	<-lwc.ch
+
+	// If there are no more waiters, we can delete the lock.
+	if lwc.count() == 0 {
+		delete(l.locks, key)
+	}
+}

--- a/internal/util/locker/locker.go
+++ b/internal/util/locker/locker.go
@@ -1,4 +1,20 @@
 /*
+Copyright 2024 IONOS Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
 Package locker provides a mechanism for fine-grained locking.
 
 In contrast to a sync.Mutex, the user must provide a key when locking and unlocking.

--- a/internal/util/locker/locker.go
+++ b/internal/util/locker/locker.go
@@ -80,13 +80,11 @@ func (lwc *lockWithCounter) count() int32 {
 func (l *Locker) Lock(ctx context.Context, key string) error {
 	l.mu.Lock()
 
-	select {
-	case <-ctx.Done():
+	if err := ctx.Err(); err != nil {
 		// ctx becoming done has "happened before" acquiring the lock, whether it became done before the call began or
 		// while we were waiting for the mutex. We prefer to fail even if we could acquire the mutex without blocking.
 		l.mu.Unlock()
-		return ctx.Err()
-	default:
+		return err
 	}
 
 	lwc, exists := l.locks[key]

--- a/internal/util/locker/locker_test.go
+++ b/internal/util/locker/locker_test.go
@@ -1,0 +1,146 @@
+package locker
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func withTimeout(t *testing.T, f func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		f()
+		close(done)
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatal("timed out")
+	case <-done:
+	}
+}
+
+func TestNew(t *testing.T) {
+	locker := New()
+	require.NotNil(t, locker)
+	require.NotNil(t, locker.locks)
+}
+
+func TestLockWithCounter(t *testing.T) {
+	lwc := &lockWithCounter{}
+	require.EqualValues(t, 0, lwc.count())
+
+	lwc.inc()
+	require.EqualValues(t, 1, lwc.count())
+
+	lwc.dec()
+	require.EqualValues(t, 0, lwc.count())
+}
+
+func TestLockerLock(t *testing.T) {
+	l := New()
+	require.NoError(t, l.Lock(context.Background(), "test"))
+	lwc := l.locks["test"]
+
+	require.EqualValues(t, 0, lwc.count())
+
+	chDone := make(chan struct{})
+	go func(t *testing.T) {
+		assert.NoError(t, l.Lock(context.Background(), "test"))
+		close(chDone)
+	}(t)
+
+	chWaiting := make(chan struct{})
+	go func() {
+		for range time.Tick(1 * time.Millisecond) {
+			if lwc.count() == 1 {
+				close(chWaiting)
+				break
+			}
+		}
+	}()
+
+	withTimeout(t, func() {
+		<-chWaiting
+	})
+
+	select {
+	case <-chDone:
+		t.Fatal("lock should not have returned while it was still held")
+	default:
+	}
+
+	l.Unlock("test")
+
+	withTimeout(t, func() {
+		<-chDone
+	})
+
+	require.EqualValues(t, 0, lwc.count())
+}
+
+func TestLockerUnlock(t *testing.T) {
+	l := New()
+
+	require.NoError(t, l.Lock(context.Background(), "test"))
+	l.Unlock("test")
+
+	require.PanicsWithValue(t, "no such lock: test", func() {
+		l.Unlock("test")
+	})
+
+	withTimeout(t, func() {
+		require.NoError(t, l.Lock(context.Background(), "test"))
+	})
+}
+
+func TestLockerConcurrency(t *testing.T) {
+	l := New()
+
+	var wg sync.WaitGroup
+	for i := 0; i <= 10_000; i++ {
+		wg.Add(1)
+		go func(t *testing.T) {
+			assert.NoError(t, l.Lock(context.Background(), "test"))
+			// If there is a concurrency issue, it will very likely become visible here.
+			l.Unlock("test")
+			wg.Done()
+		}(t)
+	}
+
+	withTimeout(t, wg.Wait)
+
+	// Since everything has unlocked the map should be empty.
+	require.Empty(t, l.locks)
+}
+
+func TestLockerContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	l := New()
+
+	withTimeout(t, func() {
+		err := l.Lock(ctx, "test")
+		require.ErrorIs(t, context.Canceled, err)
+	})
+}
+
+func TestLockerContextDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+
+	l := New()
+	require.NoError(t, l.Lock(ctx, "test"))
+
+	withTimeout(t, func() {
+		err := l.Lock(ctx, "test")
+		require.ErrorIs(t, context.DeadlineExceeded, err)
+	})
+
+	require.Empty(t, l.locks)
+}

--- a/internal/util/locker/locker_test.go
+++ b/internal/util/locker/locker_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2024 IONOS Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package locker
 
 import (

--- a/scope/machine.go
+++ b/scope/machine.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-ionoscloud/api/v1alpha1"
+	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/locker"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/ptr"
 )
 
@@ -38,6 +39,7 @@ import (
 type Machine struct {
 	client      client.Client
 	patchHelper *patch.Helper
+	Locker      *locker.Locker
 
 	Machine      *clusterv1.Machine
 	IonosMachine *infrav1.IonosCloudMachine
@@ -51,6 +53,7 @@ type MachineParams struct {
 	Machine      *clusterv1.Machine
 	ClusterScope *Cluster
 	IonosMachine *infrav1.IonosCloudMachine
+	Locker       *locker.Locker
 }
 
 // NewMachine creates a new Machine using the provided params.
@@ -67,6 +70,9 @@ func NewMachine(params MachineParams) (*Machine, error) {
 	if params.ClusterScope == nil {
 		return nil, errors.New("machine scope params need a IONOS Cloud cluster scope")
 	}
+	if params.Locker == nil {
+		return nil, errors.New("machine scope params need a locker")
+	}
 
 	helper, err := patch.NewHelper(params.IonosMachine, params.Client)
 	if err != nil {
@@ -75,6 +81,7 @@ func NewMachine(params MachineParams) (*Machine, error) {
 	return &Machine{
 		client:       params.Client,
 		patchHelper:  helper,
+		Locker:       params.Locker,
 		Machine:      params.Machine,
 		ClusterScope: params.ClusterScope,
 		IonosMachine: params.IonosMachine,

--- a/scope/machine_test.go
+++ b/scope/machine_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	infrav1 "github.com/ionos-cloud/cluster-api-provider-ionoscloud/api/v1alpha1"
+	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/locker"
 	"github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/util/ptr"
 )
 
@@ -46,6 +47,7 @@ func exampleParams(t *testing.T) MachineParams {
 			Cluster: &clusterv1.Cluster{},
 		},
 		IonosMachine: &infrav1.IonosCloudMachine{},
+		Locker:       locker.New(),
 	}
 }
 
@@ -83,6 +85,14 @@ func TestMachineParamsNilIonosMachineShouldFail(t *testing.T) {
 func TestMachineParamsNilClusterScopeShouldFail(t *testing.T) {
 	params := exampleParams(t)
 	params.ClusterScope = nil
+	scope, err := NewMachine(params)
+	require.Nil(t, scope, "returned machine scope should be nil")
+	require.Error(t, err)
+}
+
+func TestMachineParamsNilLockerShouldFail(t *testing.T) {
+	params := exampleParams(t)
+	params.Locker = nil
 	scope, err := NewMachine(params)
 	require.Nil(t, scope, "returned machine scope should be nil")
 	require.Error(t, err)


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

Improve performance by having more worker goroutines per controller.

**Description of changes:**

Besides the actual flags for specifying the number of concurrent reconciles per controller, this change adds locks as needed for thread safety.

This applies to 3 kinds of operations:
- Creating, updating and deleting LANs, as they are shared across machines.
- IP block creation and deletion for machine failover IPs, as they are shared across machines.
- Accessing the `IonosCloudCluster.Status.CurrentRequestByDatacenter` map, as it is shared across machines.

For locking, a new `locker` package was added.

**Special notes for your reviewer:**

Reviewing commit by commit should be the easiest way.

**Checklist:**
- [ ] Documentation updated
- [x] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)