### PR TITLE
:seedling: Remove CloudAPI inconsistency workaround

### DIFF
--- a/internal/service/cloud/ipblock.go
+++ b/internal/service/cloud/ipblock.go
@@ -243,7 +243,7 @@ func (s *Service) getFailoverIPBlock(ctx context.Context, ms *scope.Machine) (*s
 			continue
 		}
 		if ptr.Deref(props.GetName(), "") == s.failoverIPBlockName(ms) {
-			return s.cloudAPIStateInconsistencyWorkaround(ctx, &block)
+			return &block, nil
 		}
 	}
 
@@ -283,17 +283,10 @@ func (s *Service) getControlPlaneEndpointIPBlock(ctx context.Context, cs *scope.
 			continue
 		case ptr.Deref(props.GetName(), "") == expectedName:
 			count++
-			foundBlock, err = s.cloudAPIStateInconsistencyWorkaround(ctx, &block)
-			if err != nil {
-				return nil, err
-			}
+			foundBlock = &block
 		case s.checkIfUserSetBlock(controlPlaneEndpointIP, props):
 			// NOTE: this is for when customers set IPs for the control plane endpoint themselves.
-			foundBlock, err = s.cloudAPIStateInconsistencyWorkaround(ctx, &block)
-			if err != nil {
-				return nil, err
-			}
-			return foundBlock, nil
+			return &block, nil
 		}
 		if count > 1 {
 			return nil, fmt.Errorf(
@@ -315,18 +308,6 @@ func (s *Service) getControlPlaneEndpointIPBlock(ctx context.Context, cs *scope.
 func (*Service) checkIfUserSetBlock(controlPlaneEndpointIP string, props *sdk.IpBlockProperties) bool {
 	ips := ptr.Deref(props.GetIps(), nil)
 	return controlPlaneEndpointIP != "" && slices.Contains(ips, controlPlaneEndpointIP)
-}
-
-// cloudAPIStateInconsistencyWorkaround is a workaround for a bug where the API returns different states for the same
-// IP Block when using the ListIPBlocks method and the GetIPBlock method. This workaround uses the GetIPBlock method as
-// the source of truth to get the correct status of the IP block.
-// TODO(gfariasalves): remove this method once the bug is fixed.
-func (s *Service) cloudAPIStateInconsistencyWorkaround(ctx context.Context, block *sdk.IpBlock) (*sdk.IpBlock, error) {
-	trueBlock, err := s.ionosClient.GetIPBlock(ctx, ptr.Deref(block.GetId(), unknownValue))
-	if err != nil {
-		return nil, fmt.Errorf("could not confirm if found IP block is available: %w", err)
-	}
-	return trueBlock, nil
 }
 
 func (s *Service) getIPBlockByID(ctx context.Context, ipBlockID string) (*sdk.IpBlock, error) {

--- a/internal/service/cloud/ipblock_test.go
+++ b/internal/service/cloud/ipblock_test.go
@@ -48,7 +48,6 @@ func (s *ipBlockTestSuite) TestGetControlPlaneEndpointIPBlockMultipleMatches() {
 			*exampleIPBlock(),
 		},
 	}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(exampleIPBlock(), nil).Twice()
 	block, err := s.service.getControlPlaneEndpointIPBlock(s.ctx, s.clusterScope)
 	s.Error(err)
 	s.Nil(block)
@@ -66,7 +65,6 @@ func (s *ipBlockTestSuite) TestGetControlPlaneEndpointIPBlockSingleMatch() {
 			},
 		},
 	}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(exampleIPBlock(), nil).Once()
 	block, err := s.service.getControlPlaneEndpointIPBlock(s.ctx, s.clusterScope)
 	s.NoError(err)
 	s.NotNil(block)
@@ -83,6 +81,9 @@ func (s *ipBlockTestSuite) TestGetControlPlaneEndpointIPBlockUserSetIP() {
 		Items: &[]sdk.IpBlock{
 			{
 				Id: ptr.To(exampleIPBlockID),
+				Metadata: &sdk.DatacenterElementMetadata{
+					State: ptr.To(sdk.Available),
+				},
 				Properties: &sdk.IpBlockProperties{
 					Name:     name,
 					Location: location,
@@ -99,17 +100,7 @@ func (s *ipBlockTestSuite) TestGetControlPlaneEndpointIPBlockUserSetIP() {
 			},
 		},
 	}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(&sdk.IpBlock{
-		Metadata: &sdk.DatacenterElementMetadata{
-			State: ptr.To(sdk.Available),
-		},
-		Id: ptr.To(exampleIPBlockID),
-		Properties: &sdk.IpBlockProperties{
-			Ips: &[]string{
-				exampleEndpointIP,
-			},
-		},
-	}, nil).Once()
+
 	block, err := s.service.getControlPlaneEndpointIPBlock(s.ctx, s.clusterScope)
 	s.NoError(err)
 	s.Contains(*block.GetProperties().GetIps(), exampleEndpointIP)
@@ -254,7 +245,6 @@ func (s *ipBlockTestSuite) TestReconcileControlPlaneEndpointUserSetIP() {
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{
 		Items: &[]sdk.IpBlock{*block},
 	}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(block, nil).Once()
 	requeue, err := s.service.ReconcileControlPlaneEndpoint(s.ctx, s.clusterScope)
 	s.False(requeue)
 	s.NoError(err)
@@ -340,7 +330,6 @@ func (s *ipBlockTestSuite) TestReconcileControlPlaneEndpointDeletionUserSetIPWit
 			*block,
 		},
 	}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(block, nil).Once()
 	requeue, err := s.service.ReconcileControlPlaneEndpointDeletion(s.ctx, s.clusterScope)
 	s.False(requeue)
 	s.NoError(err)
@@ -360,7 +349,6 @@ func (s *ipBlockTestSuite) TestReconcileControlPlaneEndpointDeletionDeletionPend
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{
 		*block,
 	}}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(block, nil).Once()
 	s.mockGetIPBlocksRequestsDeleteCall(exampleIPBlockID).Return([]sdk.Request{
 		s.buildRequest(sdk.RequestStatusRunning, http.MethodDelete, exampleIPBlockID),
 	}, nil).Once()
@@ -372,12 +360,9 @@ func (s *ipBlockTestSuite) TestReconcileControlPlaneEndpointDeletionDeletionPend
 
 func (s *ipBlockTestSuite) TestReconcileControlPlaneEndpointDeletionRequestNewDeletion() {
 	block := exampleIPBlock()
-	block.Metadata.State = ptr.To(sdk.Busy)
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{
 		*block,
 	}}, nil).Once()
-	blockUpdated := exampleIPBlock()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(blockUpdated, nil).Once()
 	s.mockGetIPBlocksRequestsDeleteCall(exampleIPBlockID).Return(nil, nil).Once()
 	s.mockDeleteIPBlockCall().Return(exampleRequestPath, nil).Once()
 	requeue, err := s.service.ReconcileControlPlaneEndpointDeletion(s.ctx, s.clusterScope)
@@ -391,7 +376,6 @@ func (s *ipBlockTestSuite) TestReconcileFailoverIPBlockDeletion() {
 	ipBlock := exampleIPBlockWithName(s.service.failoverIPBlockName(s.machineScope))
 
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{*ipBlock}}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(ipBlock, nil).Once()
 	s.mockGetIPBlocksRequestsDeleteCall(exampleIPBlockID).Return(nil, nil).Once()
 	s.mockDeleteIPBlockCall().Return(exampleRequestPath, nil).Once()
 	s.mockListLANsCall().Return(&sdk.Lans{Items: &[]sdk.Lan{s.exampleLAN()}}, nil).Once()
@@ -411,7 +395,6 @@ func (s *ipBlockTestSuite) TestReconcileFailoverIPBlockDeletionSkipped() {
 	}}
 
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{*ipBlock}}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(ipBlock, nil).Once()
 	s.mockGetIPBlocksRequestsDeleteCall(exampleIPBlockID).Return(nil, nil).Once()
 	s.mockListLANsCall().Return(&sdk.Lans{Items: &[]sdk.Lan{lan}}, nil).Once()
 
@@ -440,7 +423,6 @@ func (s *ipBlockTestSuite) TestReconcileFailoverIPBlockDeletionPendingDeletion()
 	ipBlock := exampleIPBlockWithName(s.service.failoverIPBlockName(s.machineScope))
 
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{*ipBlock}}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(ipBlock, nil).Once()
 
 	deleteRequest := s.buildIPBlockRequestWithName(
 		s.service.failoverIPBlockName(s.machineScope),
@@ -468,7 +450,6 @@ func (s *ipBlockTestSuite) TestReconcileFailoverIPBlockDeletionDeletionFinished(
 	ipBlock := exampleIPBlockWithName(s.service.failoverIPBlockName(s.machineScope))
 
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{*ipBlock}}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(ipBlock, nil).Once()
 
 	deleteRequest := s.buildIPBlockRequestWithName("", sdk.RequestStatusDone, http.MethodDelete, exampleIPBlockID)
 	s.mockGetIPBlocksRequestsDeleteCall(exampleIPBlockID).Return([]sdk.Request{deleteRequest}, nil).Once()

--- a/internal/service/cloud/network_test.go
+++ b/internal/service/cloud/network_test.go
@@ -263,7 +263,6 @@ func (s *lanSuite) TestReconcileIPFailoverForWorkerWithAUTOSettings() {
 		},
 		nil).Once()
 	s.mockListIPBlocksCall().Return(&sdk.IpBlocks{Items: &[]sdk.IpBlock{ipBlock}}, nil).Once()
-	s.mockGetIPBlockByIDCall(exampleIPBlockID).Return(&ipBlock, nil).Once()
 
 	s.mockGetServerCall(exampleServerID).Return(testServer, nil).Once()
 	s.mockListLANsCall().Return(&sdk.Lans{Items: &[]sdk.Lan{testLAN}}, nil).Once()


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

Removes workaround for IP Blocks.

**Description of changes:**

There was a bug, which caused IP blocks, that have been retrieved as a list via Cloud API, to always return in state "BUSY" and we needed to always perform a second request to GET the IPBlock in the actual state.

This issue has been fixed, therefore the workaround can be removed.


**Checklist:**
- [x] Unit Tests updated
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)