### PR TITLE
🐛 Use correct machine counts for high availability test

### DIFF
--- a/test/e2e/capic_test.go
+++ b/test/e2e/capic_test.go
@@ -40,8 +40,8 @@ var _ = Describe("Should be able to create a cluster with 3 control-plane and 2 
 			BootstrapClusterProxy:    bootstrapClusterProxy,
 			ArtifactFolder:           artifactFolder,
 			SkipCleanup:              skipCleanup,
-			ControlPlaneMachineCount: ptr.To[int64](1),
-			WorkerMachineCount:       ptr.To[int64](1),
+			ControlPlaneMachineCount: ptr.To[int64](3),
+			WorkerMachineCount:       ptr.To[int64](2),
 			PostNamespaceCreated:     cloudEnv.createCredentialsSecretPNC,
 			PostMachinesProvisioned: func(proxy framework.ClusterProxy, namespace, clusterName string) {
 				// This check ensures that owner references are resilient - i.e. correctly re-reconciled - when removed.


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

I just noticed the high availability test creates only 1 control plane node and 1 worker node. This mistake happened while testing the tests. This PR fixes the incongruence.

**Issue #, if available:**

N/A

**Description of changes:**

High availability test now creates 3 and 2 CP and worker nodes, respectively.

**Special notes for your reviewer:**

**Checklist:**
- [x] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)