### PR TITLE
:bug: Fix deletion patch error

### DIFF
--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -287,7 +287,7 @@ func (*IonosCloudMachineReconciler) checkRequestStates(
 			)
 
 			// We need to patch the machine during the deletion phase to make sure we do
-			// not have a diff in the status during the final patch when the finalizer is removed
+			// not have a diff in the status during the final patch when the finalizer is removed.
 			if !machineScope.IonosMachine.DeletionTimestamp.IsZero() {
 				requeue, retErr = true, machineScope.PatchObject()
 			}

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -286,8 +286,8 @@ func (*IonosCloudMachineReconciler) checkRequestStates(
 				},
 			)
 
-			// We would like to patch the machine in the deletion step to
-			// not have a diff in the status during the final patch
+			// We need to patch the machine during the deletion phase to make sure we do
+			// not have a diff in the status during the final patch when the finalizer is removed
 			if !machineScope.IonosMachine.DeletionTimestamp.IsZero() {
 				requeue, retErr = true, machineScope.PatchObject()
 			}

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -215,7 +215,7 @@ func (r *IonosCloudMachineReconciler) reconcileDelete(
 
 	if requeue {
 		log.Info("Deletion request is still in progress")
-		return ctrl.Result{RequeueAfter: defaultReconcileDuration}, nil
+		return ctrl.Result{RequeueAfter: reducedReconcileDuration}, nil
 	}
 
 	reconcileSequence := []serviceReconcileStep[scope.Machine]{

--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -237,7 +237,6 @@ func (r *IonosCloudMachineReconciler) reconcileDelete(
 			return ctrl.Result{RequeueAfter: defaultReconcileDuration}, err
 		}
 	}
-
 	controllerutil.RemoveFinalizer(machineScope.IonosMachine, infrav1.MachineFinalizer)
 	return ctrl.Result{}, nil
 }
@@ -286,6 +285,12 @@ func (*IonosCloudMachineReconciler) checkRequestStates(
 					return nil
 				},
 			)
+
+			// We would like to patch the machine in the deletion step to
+			// not have a diff in the status during the final patch
+			if !machineScope.IonosMachine.DeletionTimestamp.IsZero() {
+				requeue, retErr = true, machineScope.PatchObject()
+			}
 		}
 	}
 

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	defaultReconcileDuration = time.Second * 20
+	reducedReconcileDuration = time.Second * 10
 )
 
 type serviceReconcileStep[T scope.Cluster | scope.Machine] struct {


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

This PR fixes a bug that occurs during the deletion of machines.

The patch helper will always calculate a diff and patch the resource and status accordingly. At the time of the deletion when removing the finalizer, we need to make sure, that there is no more change in the status anymore. We are always checking for requests at the beginning of a reconcile function. Those requests are stored in the status and upon completion, those will be removed from the status. The machine controller will patch the status in the end.

The order of the patch helper is
1. Patch object
2. Patch status

When the finalizer is removed and the object patch completed, the resource is gone. The next patch request against the status will therefore fail with a `NotFound` error.

**Description of changes:**

Adds a check to the `checkRequestStates` function that will patch the object and requeue before proceeding with the deletion logic.

**Checklist:**
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)