### PR TITLE
:sparkles: Prepare kamaji setup

### DIFF
--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -152,7 +152,7 @@ func (r *IonosCloudClusterReconciler) reconcileNormal(
 	var reconcileSequence []serviceReconcileStep[scope.Cluster]
 	// TODO: This logic needs to move to another controller.
 	if clusterScope.IonosCluster.Spec.LoadBalancerProviderRef != nil {
-		// Reserving IP Blocks only makes sense for LB implementations or HA setup with kube-vip
+		// Reserving IP Blocks only makes sense for LB implementations or HA setup with kube-vip.
 		//
 		// As we are currently expecting to supply the control plane endpoint manually,
 		// logic-wise nothing changes for us. As soon as we have implemented


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

We need to make sure, not to reconcile IP Blocks for the control plane, if we do not specify a LB controller.

**Description of changes:**

This change is required for a setup with Kamaji. The logic needs to be moved in the future anyways and automatically reserving IP Blocks for a HA control plane was not yet supported anyways

**Checklist:**
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)