### PR TITLE
✨ Handle IP blocks based on VDC location

### DIFF
--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -277,6 +277,10 @@ type IonosCloudMachineStatus struct {
 	// cloud resource that is being provisioned.
 	//+optional
 	CurrentRequest *ProvisioningRequest `json:"currentRequest,omitempty"`
+
+	// Location is the location of the datacenter the VM is provisioned in.
+	//+optional
+	Location string `json:"location"`
 }
 
 // MachineNetworkInfo contains information about the network configuration of the VM.

--- a/api/v1alpha1/ionoscloudmachine_types_test.go
+++ b/api/v1alpha1/ionoscloudmachine_types_test.go
@@ -451,6 +451,7 @@ var _ = Describe("IonosCloudMachine Tests", func() {
 			}
 			m.Status.FailureReason = ptr.To(errors.InvalidConfigurationMachineError)
 			m.Status.FailureMessage = ptr.To("Failure message")
+			m.Status.Location = "de/fra"
 
 			m.Status.MachineNetworkInfo = &MachineNetworkInfo{
 				NICInfo: []NICInfo{

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachines.yaml
@@ -317,6 +317,10 @@ spec:
                   can be added as events to the IonosCloudMachine object and/or logged in the
                   controller's output.
                 type: string
+              location:
+                description: Location is the location of the datacenter the VM is
+                  provisioned in.
+                type: string
               machineNetworkInfo:
                 description: |-
                   MachineNetworkInfo contains information about the network configuration of the VM.

--- a/internal/ionoscloud/client.go
+++ b/internal/ionoscloud/client.go
@@ -67,5 +67,5 @@ type Client interface {
 	// PatchNIC updates the NIC identified by nicID with the provided properties, returning the request location.
 	PatchNIC(ctx context.Context, datacenterID, serverID, nicID string, properties sdk.NicProperties) (string, error)
 	// GetDatacenterLocationByID returns the location of the data center identified by datacenterID.
-	GetDatacenterLocationByID(datacenterID string) (string, error)
+	GetDatacenterLocationByID(ctx context.Context, datacenterID string) (string, error)
 }

--- a/internal/ionoscloud/client.go
+++ b/internal/ionoscloud/client.go
@@ -66,4 +66,6 @@ type Client interface {
 	GetRequests(ctx context.Context, method, path string) ([]sdk.Request, error)
 	// PatchNIC updates the NIC identified by nicID with the provided properties, returning the request location.
 	PatchNIC(ctx context.Context, datacenterID, serverID, nicID string, properties sdk.NicProperties) (string, error)
+	// GetDatacenterLocationByID returns the location of the data center identified by datacenterID.
+	GetDatacenterLocationByID(datacenterID string) (string, error)
 }

--- a/internal/ionoscloud/client/client.go
+++ b/internal/ionoscloud/client/client.go
@@ -465,12 +465,12 @@ func validateNICParameters(datacenterID, serverID, nicID string) (err error) {
 }
 
 // GetDatacenterLocationByID returns the location of the data center identified by datacenterID.
-func (c *IonosCloudClient) GetDatacenterLocationByID(datacenterID string) (string, error) {
+func (c *IonosCloudClient) GetDatacenterLocationByID(ctx context.Context, datacenterID string) (string, error) {
 	if datacenterID == "" {
 		return "", errDatacenterIDIsEmpty
 	}
 
-	datacenter, _, err := c.API.DataCentersApi.DatacentersFindById(context.Background(), datacenterID).Execute()
+	datacenter, _, err := c.API.DataCentersApi.DatacentersFindById(ctx, datacenterID).Execute()
 	if err != nil {
 		return "", fmt.Errorf(apiCallErrWrapper, err)
 	}

--- a/internal/ionoscloud/client/client.go
+++ b/internal/ionoscloud/client/client.go
@@ -463,3 +463,17 @@ func validateNICParameters(datacenterID, serverID, nicID string) (err error) {
 
 	return nil
 }
+
+// GetDatacenterLocationByID returns the location of the data center identified by datacenterID.
+func (c *IonosCloudClient) GetDatacenterLocationByID(datacenterID string) (string, error) {
+	if datacenterID == "" {
+		return "", errDatacenterIDIsEmpty
+	}
+
+	datacenter, _, err := c.API.DataCentersApi.DatacentersFindById(context.Background(), datacenterID).Execute()
+	if err != nil {
+		return "", fmt.Errorf(apiCallErrWrapper, err)
+	}
+
+	return *datacenter.Properties.Location, nil
+}

--- a/internal/ionoscloud/clienttest/mock_client.go
+++ b/internal/ionoscloud/clienttest/mock_client.go
@@ -455,6 +455,62 @@ func (_c *MockClient_DeleteVolume_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// GetDatacenterLocationByID provides a mock function with given fields: datacenterID
+func (_m *MockClient) GetDatacenterLocationByID(datacenterID string) (string, error) {
+	ret := _m.Called(datacenterID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatacenterLocationByID")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(datacenterID)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(datacenterID)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(datacenterID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_GetDatacenterLocationByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDatacenterLocationByID'
+type MockClient_GetDatacenterLocationByID_Call struct {
+	*mock.Call
+}
+
+// GetDatacenterLocationByID is a helper method to define mock.On call
+//   - datacenterID string
+func (_e *MockClient_Expecter) GetDatacenterLocationByID(datacenterID interface{}) *MockClient_GetDatacenterLocationByID_Call {
+	return &MockClient_GetDatacenterLocationByID_Call{Call: _e.mock.On("GetDatacenterLocationByID", datacenterID)}
+}
+
+func (_c *MockClient_GetDatacenterLocationByID_Call) Run(run func(datacenterID string)) *MockClient_GetDatacenterLocationByID_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockClient_GetDatacenterLocationByID_Call) Return(_a0 string, _a1 error) *MockClient_GetDatacenterLocationByID_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClient_GetDatacenterLocationByID_Call) RunAndReturn(run func(string) (string, error)) *MockClient_GetDatacenterLocationByID_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetIPBlock provides a mock function with given fields: ctx, ipBlockID
 func (_m *MockClient) GetIPBlock(ctx context.Context, ipBlockID string) (*ionoscloud.IpBlock, error) {
 	ret := _m.Called(ctx, ipBlockID)

--- a/internal/ionoscloud/clienttest/mock_client.go
+++ b/internal/ionoscloud/clienttest/mock_client.go
@@ -455,9 +455,9 @@ func (_c *MockClient_DeleteVolume_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
-// GetDatacenterLocationByID provides a mock function with given fields: datacenterID
-func (_m *MockClient) GetDatacenterLocationByID(datacenterID string) (string, error) {
-	ret := _m.Called(datacenterID)
+// GetDatacenterLocationByID provides a mock function with given fields: ctx, datacenterID
+func (_m *MockClient) GetDatacenterLocationByID(ctx context.Context, datacenterID string) (string, error) {
+	ret := _m.Called(ctx, datacenterID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDatacenterLocationByID")
@@ -465,17 +465,17 @@ func (_m *MockClient) GetDatacenterLocationByID(datacenterID string) (string, er
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
-		return rf(datacenterID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, datacenterID)
 	}
-	if rf, ok := ret.Get(0).(func(string) string); ok {
-		r0 = rf(datacenterID)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, datacenterID)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(datacenterID)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, datacenterID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -489,14 +489,15 @@ type MockClient_GetDatacenterLocationByID_Call struct {
 }
 
 // GetDatacenterLocationByID is a helper method to define mock.On call
+//   - ctx context.Context
 //   - datacenterID string
-func (_e *MockClient_Expecter) GetDatacenterLocationByID(datacenterID interface{}) *MockClient_GetDatacenterLocationByID_Call {
-	return &MockClient_GetDatacenterLocationByID_Call{Call: _e.mock.On("GetDatacenterLocationByID", datacenterID)}
+func (_e *MockClient_Expecter) GetDatacenterLocationByID(ctx interface{}, datacenterID interface{}) *MockClient_GetDatacenterLocationByID_Call {
+	return &MockClient_GetDatacenterLocationByID_Call{Call: _e.mock.On("GetDatacenterLocationByID", ctx, datacenterID)}
 }
 
-func (_c *MockClient_GetDatacenterLocationByID_Call) Run(run func(datacenterID string)) *MockClient_GetDatacenterLocationByID_Call {
+func (_c *MockClient_GetDatacenterLocationByID_Call) Run(run func(ctx context.Context, datacenterID string)) *MockClient_GetDatacenterLocationByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -506,7 +507,7 @@ func (_c *MockClient_GetDatacenterLocationByID_Call) Return(_a0 string, _a1 erro
 	return _c
 }
 
-func (_c *MockClient_GetDatacenterLocationByID_Call) RunAndReturn(run func(string) (string, error)) *MockClient_GetDatacenterLocationByID_Call {
+func (_c *MockClient_GetDatacenterLocationByID_Call) RunAndReturn(run func(context.Context, string) (string, error)) *MockClient_GetDatacenterLocationByID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/service/cloud/ipblock.go
+++ b/internal/service/cloud/ipblock.go
@@ -237,7 +237,7 @@ func (s *Service) getFailoverIPBlock(ctx context.Context, ms *scope.Machine) (*s
 		return nil, fmt.Errorf("failed to list IP blocks: %w", err)
 	}
 
-	location, err := s.ionosClient.GetDatacenterLocationByID(ms.IonosMachine.Spec.DatacenterID)
+	location, err := s.ionosClient.GetDatacenterLocationByID(ctx, ms.IonosMachine.Spec.DatacenterID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get location of datacenter: %w", err)
 	}
@@ -339,7 +339,7 @@ func (s *Service) reserveControlPlaneEndpointIPBlock(ctx context.Context, cs *sc
 
 func (s *Service) reserveMachineDeploymentFailoverIPBlock(ctx context.Context, ms *scope.Machine) error {
 	log := s.logger.WithName("reserveMachineDeploymentFailoverIPBlock")
-	location, err := s.ionosClient.GetDatacenterLocationByID(ms.IonosMachine.Spec.DatacenterID)
+	location, err := s.ionosClient.GetDatacenterLocationByID(ctx, ms.IonosMachine.Spec.DatacenterID)
 	if err != nil {
 		return fmt.Errorf("failed to get location of datacenter: %w", err)
 	}
@@ -413,7 +413,7 @@ func (s *Service) getLatestControlPlaneEndpointIPBlockCreationRequest(
 
 // getLatestFailoverIPBlockCreateRequest returns the latest failover IP block creation request.
 func (s *Service) getLatestFailoverIPBlockCreateRequest(ctx context.Context, ms *scope.Machine) (*requestInfo, error) {
-	location, err := s.ionosClient.GetDatacenterLocationByID(ms.IonosMachine.Spec.DatacenterID)
+	location, err := s.ionosClient.GetDatacenterLocationByID(ctx, ms.IonosMachine.Spec.DatacenterID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get location of datacenter: %w", err)
 	}

--- a/internal/service/cloud/ipblock_test.go
+++ b/internal/service/cloud/ipblock_test.go
@@ -179,7 +179,7 @@ func (s *ipBlockTestSuite) TestReserveMachineDeploymentIPBlockRequestSuccess() {
 	s.NoError(err)
 	req := s.machineScope.IonosMachine.Status.CurrentRequest
 	s.validateRequest(http.MethodPost, sdk.RequestStatusQueued, requestPath, req)
-	s.validateSuccessfulReservation(s.machineScope.IonosMachine.Status.Location, err)
+	s.Equal(exampleLocation, s.machineScope.IonosMachine.Status.Location)
 }
 
 func (s *ipBlockTestSuite) validateRequest(method, state, path string, req *infrav1.ProvisioningRequest) {
@@ -189,12 +189,6 @@ func (s *ipBlockTestSuite) validateRequest(method, state, path string, req *infr
 	s.Equal(method, req.Method)
 	s.Equal(state, req.State)
 	s.Equal(path, req.RequestPath)
-}
-
-func (s *ipBlockTestSuite) validateSuccessfulReservation(location string, err error) {
-	s.T().Helper()
-	s.NoError(err)
-	s.Equal(exampleLocation, location)
 }
 
 func (s *ipBlockTestSuite) TestDeleteControlPlaneEndpointIPBlockRequestSuccess() {

--- a/internal/service/cloud/ipblock_test.go
+++ b/internal/service/cloud/ipblock_test.go
@@ -434,7 +434,7 @@ func (s *ipBlockTestSuite) TestReconcileFailoverIPBlockDeletionSkipped() {
 func (s *ipBlockTestSuite) TestReconcileFailoverIPBlockDeletionPendingCreation() {
 	s.infraMachine.Spec.FailoverIP = ptr.To(infrav1.CloudResourceConfigAuto)
 
-	s.mockGetDatacenterLocationByIDCall(exampleDatacenterID).Return(exampleLocation, nil).Twice()
+	s.mockGetDatacenterLocationByIDCall(exampleDatacenterID).Return(exampleLocation, nil).Once()
 	s.mockListIPBlocksCall().Return(nil, nil).Once()
 	s.mockGetIPBlocksRequestsPostCall().Return([]sdk.Request{
 		s.buildIPBlockRequestWithName(

--- a/internal/service/cloud/network_test.go
+++ b/internal/service/cloud/network_test.go
@@ -286,7 +286,7 @@ func (s *lanSuite) TestReconcileIPFailoverReserveIPBlock() {
 	s.infraMachine.SetLabels(map[string]string{clusterv1.MachineDeploymentNameLabel: deploymentLabel})
 	s.infraMachine.Spec.FailoverIP = ptr.To(infrav1.CloudResourceConfigAuto)
 
-	s.mockGetDatacenterLocationByIDCall(exampleDatacenterID).Return(exampleLocation, nil).Times(3)
+	s.mockGetDatacenterLocationByIDCall(exampleDatacenterID).Return(exampleLocation, nil).Once()
 	s.mockListIPBlocksCall().Return(nil, nil).Once()
 	s.mockGetIPBlocksRequestsPostCall().Return(nil, nil).Once()
 	s.mockReserveIPBlockCall(s.service.failoverIPBlockName(s.machineScope), s.clusterScope.Location()).

--- a/internal/service/cloud/network_test.go
+++ b/internal/service/cloud/network_test.go
@@ -248,6 +248,7 @@ func (s *lanSuite) TestReconcileIPFailoverForWorkerWithAUTOSettings() {
 	s.infraMachine.Spec.FailoverIP = ptr.To(infrav1.CloudResourceConfigAuto)
 	testServer := s.defaultServer(s.infraMachine, exampleDHCPIP, exampleWorkerFailoverIP)
 	testLAN := s.exampleLAN()
+	s.mockGetDatacenterLocationByIDCall(exampleDatacenterID).Return(exampleLocation, nil)
 
 	ipBlock := s.exampleIPBlock()
 
@@ -285,6 +286,7 @@ func (s *lanSuite) TestReconcileIPFailoverReserveIPBlock() {
 	s.infraMachine.SetLabels(map[string]string{clusterv1.MachineDeploymentNameLabel: deploymentLabel})
 	s.infraMachine.Spec.FailoverIP = ptr.To(infrav1.CloudResourceConfigAuto)
 
+	s.mockGetDatacenterLocationByIDCall(exampleDatacenterID).Return(exampleLocation, nil).Times(3)
 	s.mockListIPBlocksCall().Return(nil, nil).Once()
 	s.mockGetIPBlocksRequestsPostCall().Return(nil, nil).Once()
 	s.mockReserveIPBlockCall(s.service.failoverIPBlockName(s.machineScope), s.clusterScope.Location()).

--- a/internal/service/cloud/suite_test.go
+++ b/internal/service/cloud/suite_test.go
@@ -373,5 +373,5 @@ func (s *ServiceTestSuite) mockListLANsCall() *clienttest.MockClient_ListLANs_Ca
 }
 
 func (s *ServiceTestSuite) mockGetDatacenterLocationByIDCall(datacenterID string) *clienttest.MockClient_GetDatacenterLocationByID_Call {
-	return s.ionosClient.EXPECT().GetDatacenterLocationByID(datacenterID)
+	return s.ionosClient.EXPECT().GetDatacenterLocationByID(s.ctx, datacenterID)
 }

--- a/internal/service/cloud/suite_test.go
+++ b/internal/service/cloud/suite_test.go
@@ -73,6 +73,7 @@ const (
 	exampleSecondaryServerID = "dd426c63-cd1d-4c02-aca3-13b4a27c2ebd"
 	exampleRequestPath       = "/test"
 	exampleLocation          = "de/txl"
+	exampleDatacenterID      = "ccf27092-34e8-499e-a2f5-2bdee9d34a12"
 )
 
 type ServiceTestSuite struct {
@@ -369,4 +370,8 @@ func (s *ServiceTestSuite) mockGetServerCall(serverID string) *clienttest.MockCl
 
 func (s *ServiceTestSuite) mockListLANsCall() *clienttest.MockClient_ListLANs_Call {
 	return s.ionosClient.EXPECT().ListLANs(s.ctx, s.machineScope.DatacenterID())
+}
+
+func (s *ServiceTestSuite) mockGetDatacenterLocationByIDCall(datacenterID string) *clienttest.MockClient_GetDatacenterLocationByID_Call {
+	return s.ionosClient.EXPECT().GetDatacenterLocationByID(datacenterID)
 }


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**
If you specify a different VDC ID in the IonosCloudMachine spec, IP blocks are now correctly booked in this location.

**Issue #, if available:**
#154

**Description of changes:**
* IP blocks are booked in the location specified in the IonosCloudMachine spec
* Location is written into the Machine status

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [x] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)