### PR TITLE
🌱 Group cluster-api dependencies in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       - k8s.io/api
       - k8s.io/apimachinery
       - k8s.io/client-go
+    cluster-api:
+      patterns:
+      - sigs.k8s.io/cluster-api
+      - sigs.k8s.io/cluster-api/test
+  labels:
+  - "area/dependency"
 
 - package-ecosystem: "docker"
   directory: "/"


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**
Dependabot currently creates 2 seperate PRs for `sigs.k8s.io/cluster-api` and `sigs.k8s.io/cluster-api/test`. This leads to broken e2e tests in both branches, because both have to be bumped to the same version.

**Description of changes:**
Group cluster-api dependencies in Dependabot config

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)