### PR TITLE
🌱 Group dependabot `k8s.io/*` PRs to major/minor and patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,14 @@ updates:
   commit-message:
     prefix: ":seedling:"
   groups:
-    kubernetes:
+    kubernetes-major-minor:
       patterns:
-      - k8s.io/api
-      - k8s.io/apimachinery
-      - k8s.io/client-go
+      - k8s.io/*
+      update-types: ["major", "minor"]
+    kubernetes-patches:
+      patterns:
+      - k8s.io/*
+      update-types: ["patch"]
     cluster-api:
       patterns:
       - sigs.k8s.io/cluster-api


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**
We want to group our Dependabot `k8s.io/*` PRs into minor/major and patches. Patches can be done automatically, but major and minor should be done manually.

**Issue #, if available:**

**Description of changes:**
Create 2 Dependabot groups to split `k8s.io/*` version updates

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)