### PR TITLE
🌱 Use ignoring for dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,18 +8,32 @@ updates:
   commit-message:
     prefix: ":seedling:"
   groups:
-    kubernetes-major-minor:
-      patterns:
-      - k8s.io/*
-      update-types: ["major", "minor"]
-    kubernetes-patches:
-      patterns:
-      - k8s.io/*
-      update-types: ["patch"]
+    all-go-mod-patch-and-minor:
+      patterns: ["*"]
+      update-types: ["patch", "minor"]
     cluster-api:
       patterns:
       - sigs.k8s.io/cluster-api
       - sigs.k8s.io/cluster-api/test
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+    update-types:
+      ["version-update:semver-major", "version-update:semver-minor"]
+    # Ignore k8s and its transitives modules as they are upgraded manually together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+    update-types:
+      ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "go.etcd.io/*"
+    update-types:
+      ["version-update:semver-major", "version-update:semver-minor"]
+  - dependency-name: "google.golang.org/grpc"
+    update-types:
+      ["version-update:semver-major", "version-update:semver-minor"]
+    # Bumping the kustomize API independently can break compatibility with client-go as they share k8s.io/kube-openapi as a dependency.
+  - dependency-name: "sigs.k8s.io/kustomize/api"
+    update-types:
+      ["version-update:semver-major", "version-update:semver-minor"]
   labels:
   - "area/dependency"
 


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**
We want to use ignoring for our Dependabot config. Now only patch version updates from `k8s.io/*` are getting created.

**Issue #, if available:**

**Description of changes:**

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)