### PR TITLE
:seedling: Fix docker build warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.22 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

Fixes docker build warning:

```
 1 warning found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```

**Issue #, if available:**

**Description of changes:**

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
