### PR TITLE
:bug: Fix cluster deletion without LB ref

### DIFF
--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -207,9 +207,14 @@ func (r *IonosCloudClusterReconciler) reconcileDelete(
 		return ctrl.Result{RequeueAfter: defaultReconcileDuration}, nil
 	}
 
-	reconcileSequence := []serviceReconcileStep[scope.Cluster]{
-		{"ReconcileControlPlaneEndpointDeletion", cloudService.ReconcileControlPlaneEndpointDeletion},
+	var reconcileSequence []serviceReconcileStep[scope.Cluster]
+	// TODO: This logic needs to move to another controller.
+	if clusterScope.IonosCluster.Spec.LoadBalancerProviderRef != nil {
+		reconcileSequence = []serviceReconcileStep[scope.Cluster]{
+			{"ReconcileControlPlaneEndpointDeletion", cloudService.ReconcileControlPlaneEndpointDeletion},
+		}
 	}
+
 	for _, step := range reconcileSequence {
 		if requeue, err := step.fn(ctx, clusterScope); err != nil || requeue {
 			if err != nil {


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

Fixes NPE when trying to delete a cluster without LB ref.

```
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1bb59f7]

goroutine 194 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x1de3520?, 0x3579790?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/service/cloud.(*Service).ReconcileControlPlaneEndpointDeletion(0xc0007e8030, {0x240f280, 0xc0008a0a20}, 0xc0002588c0
)
        /workspace/internal/service/cloud/ipblock.go:132 +0x537
github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/controller.(*IonosCloudClusterReconciler).reconcileDelete(0xc000598040, {0x240f280, 0xc0008a0a20}, 0xc0002588c0, 0xc
0007e8030)
        /workspace/internal/controller/ionoscloudcluster_controller.go:214 +0x3eb
github.com/ionos-cloud/cluster-api-provider-ionoscloud/internal/controller.(*IonosCloudClusterReconciler).Reconcile(0xc000598040, {0x240f280, 0xc0008a0a20}, 0xc000708680)
        /workspace/internal/controller/ionoscloudcluster_controller.go:127 +0x4b6
sigs.k8s.io/controller-runtime/pkg/reconcile.(*objectReconcilerAdapter[...]).Reconcile(0x23f1820, {0x240f280, 0xc0008a0a20}, {{{0xc0007dac06, 0xc000797ce0?}, {0xc000273578?, 0x0?}}
})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/reconcile/reconcile.go:142 +0x194
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x2414c90?, {0x240f280?, 0xc0008a0a20?}, {{{0xc0007dac06?, 0xb?}, {0xc000273578?, 0x0?}}})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000556280, {0x240f2b8, 0xc000573ef0}, {0x1e985c0, 0xc0005983c0})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:316 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000556280, {0x240f2b8, 0xc000573ef0})
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:266 +0x1be
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:227 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 102
        /go/pkg/mod/sigs.k8s.io/controller-runtime@v0.17.3/pkg/internal/controller/controller.go:223 +0x50c
```

**Issue #, if available:**

**Description of changes:**

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
