### PR TITLE
:sparkles: allow mutation of control plane endpoint

### DIFF
--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -37,8 +37,7 @@ const (
 // IonosCloudClusterSpec defines the desired state of IonosCloudCluster.
 type IonosCloudClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
-	//+kubebuilder:validation:XValidation:rule="self.host == oldSelf.host || oldSelf.host == ''",message="control plane endpoint host cannot be updated"
-	//+kubebuilder:validation:XValidation:rule="self.port == oldSelf.port || oldSelf.port == 0",message="control plane endpoint port cannot be updated"
+	// +kubebuilder:validation:XValidation:rule="size(self.host) == 0 && self.port == 0 || self.port > 0 && self.port < 65536",message="port must be within 1-65535"
 	//
 	// TODO(gfariasalves): as of now, IP must be provided by the user as we still don't insert the
 	// provider-provided block IP into the kube-vip manifest.

--- a/api/v1alpha1/ionoscloudcluster_types_test.go
+++ b/api/v1alpha1/ionoscloudcluster_types_test.go
@@ -104,34 +104,20 @@ var _ = Describe("IonosCloudCluster", func() {
 		})
 
 		When("trying to update the control plane endpoint", func() {
-			It("should fail if the host is already set", func() {
+			It("should fail when attempting to set an invalid port number", func() {
 				cluster := defaultCluster()
 				Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
 
-				cluster.Spec.ControlPlaneEndpoint.Host = newValueStr
-				Expect(k8sClient.Update(context.Background(), cluster)).ToNot(Succeed())
+				cluster.Spec.ControlPlaneEndpoint.Port = 0
+				Expect(k8sClient.Update(context.Background(), cluster)).
+					Should(MatchError(ContainSubstring("port must be within 1-65535")))
 			})
-			It("should work if the endpoint host is not set", func() {
-				cluster := defaultCluster()
-				cluster.Spec.ControlPlaneEndpoint.Host = ""
-				Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
-
-				cluster.Spec.ControlPlaneEndpoint.Host = newValueStr
-				Expect(k8sClient.Update(context.Background(), cluster)).To(Succeed())
-			})
-			It("should fail if the port is already set", func() {
+			It("should not fail when updating the endpoint correctly", func() {
 				cluster := defaultCluster()
 				Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
 
 				cluster.Spec.ControlPlaneEndpoint.Port = 1234
-				Expect(k8sClient.Update(context.Background(), cluster)).ToNot(Succeed())
-			})
-			It("should work if the endpoint port is not set", func() {
-				cluster := defaultCluster()
-				cluster.Spec.ControlPlaneEndpoint.Port = 0
-				Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
-
-				cluster.Spec.ControlPlaneEndpoint.Port = 4657
+				cluster.Spec.ControlPlaneEndpoint.Host = "example.org"
 				Expect(k8sClient.Update(context.Background(), cluster)).To(Succeed())
 			})
 		})

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -77,10 +77,9 @@ spec:
                 - port
                 type: object
                 x-kubernetes-validations:
-                - message: control plane endpoint host cannot be updated
-                  rule: self.host == oldSelf.host || oldSelf.host == ''
-                - message: control plane endpoint port cannot be updated
-                  rule: self.port == oldSelf.port || oldSelf.port == 0
+                - message: port must be within 1-65535
+                  rule: size(self.host) == 0 && self.port == 0 || self.port > 0 &&
+                    self.port < 65536
               credentialsRef:
                 description: CredentialsRef is a reference to the secret containing
                   the credentials to access the IONOS Cloud API.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
@@ -69,10 +69,9 @@ spec:
                         - port
                         type: object
                         x-kubernetes-validations:
-                        - message: control plane endpoint host cannot be updated
-                          rule: self.host == oldSelf.host || oldSelf.host == ''
-                        - message: control plane endpoint port cannot be updated
-                          rule: self.port == oldSelf.port || oldSelf.port == 0
+                        - message: port must be within 1-65535
+                          rule: size(self.host) == 0 && self.port == 0 || self.port
+                            > 0 && self.port < 65536
                       credentialsRef:
                         description: CredentialsRef is a reference to the secret containing
                           the credentials to access the IONOS Cloud API.


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

We want to allow users to change the control plane endpoint if needed.  

**Description of changes:**

Removes the CEL validation that will prevent an update to the control plane endpoint

**Special notes for your reviewer:**

**Checklist:**
- [x] Unit Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)