### PR TITLE
:sparkles: Allow empty location for externally managed control plane endpoint

### DIFF
--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -34,6 +34,8 @@ const (
 	IonosCloudClusterKind = "IonosCloudCluster"
 )
 
+//+kubebuilder:validation:XValidation:rule="self.controlPlaneEndpoint.host == '' || has(self.location)",message="location is required when controlPlaneEndpoint.host is set"
+
 // IonosCloudClusterSpec defines the desired state of IonosCloudCluster.
 type IonosCloudClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
@@ -44,10 +46,12 @@ type IonosCloudClusterSpec struct {
 	ControlPlaneEndpoint clusterv1.APIEndpoint `json:"controlPlaneEndpoint,omitempty"`
 
 	// Location is the location where the data centers should be located.
+	//
 	//+kubebuilder:validation:XValidation:rule="self == oldSelf",message="location is immutable"
 	//+kubebuilder:example=de/txl
 	//+kubebuilder:validation:MinLength=1
-	Location string `json:"location"`
+	//+optional
+	Location string `json:"location,omitempty"`
 
 	// CredentialsRef is a reference to the secret containing the credentials to access the IONOS Cloud API.
 	//+kubebuilder:validation:XValidation:rule="has(self.name) && self.name != ''",message="credentialsRef.name must be provided"

--- a/api/v1alpha1/ionoscloudcluster_types_test.go
+++ b/api/v1alpha1/ionoscloudcluster_types_test.go
@@ -86,11 +86,17 @@ var _ = Describe("IonosCloudCluster", func() {
 			Expect(k8sClient.Create(context.Background(), cluster)).
 				Should(MatchError(ContainSubstring("credentialsRef.name must be provided")))
 		})
-		It("should not allow creating clusters with empty location", func() {
+		It("should not allow creating clusters with empty location when ControlPlaneEndpoint host is set", func() {
 			cluster := defaultCluster()
 			cluster.Spec.Location = ""
 			Expect(k8sClient.Create(context.Background(), cluster)).
-				Should(MatchError(ContainSubstring("spec.location in body should be at least 1 chars long")))
+				Should(MatchError(ContainSubstring("location is required when controlPlaneEndpoint.host is set")))
+		})
+		It("should allow creating clusters with empty location when ControlPlaneEndpoint host is not set", func() {
+			cluster := defaultCluster()
+			cluster.Spec.Location = ""
+			cluster.Spec.ControlPlaneEndpoint.Host = ""
+			Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
 		})
 	})
 

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -119,8 +119,10 @@ spec:
                   rule: self == oldSelf
             required:
             - credentialsRef
-            - location
             type: object
+            x-kubernetes-validations:
+            - message: location is required when controlPlaneEndpoint.host is set
+              rule: self.controlPlaneEndpoint.host == '' || has(self.location)
           status:
             description: IonosCloudClusterStatus defines the observed state of IonosCloudCluster.
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
@@ -111,8 +111,11 @@ spec:
                           rule: self == oldSelf
                     required:
                     - credentialsRef
-                    - location
                     type: object
+                    x-kubernetes-validations:
+                    - message: location is required when controlPlaneEndpoint.host
+                        is set
+                      rule: self.controlPlaneEndpoint.host == '' || has(self.location)
                 required:
                 - spec
                 type: object


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

The location on clusters is not needed when the control plane endpoint is managed by an external component, e.g. kamaji.

**Issue #, if available:**

**Description of changes:**

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [x] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
