### PR TITLE
:sparkles: Add image resolution policy

### DIFF
--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -240,12 +240,31 @@ type ImageSpec struct {
 	Selector *ImageSelector `json:"selector,omitempty"`
 }
 
+// ImageSelectorResolutionPolicy defines what action to take when the image selector has ambiguous results.
+// +kubebuilder:validation:Enum=Exact;Newest
+type ImageSelectorResolutionPolicy string
+
+const (
+	// ResolutionPolicyExact only succeeds if the image selector resolves to exactly 1 image.
+	ResolutionPolicyExact ImageSelectorResolutionPolicy = "Exact"
+	// ResolutionPolicyNewest uses the newest entry if the image selector resolves to more than 1 image.
+	ResolutionPolicyNewest ImageSelectorResolutionPolicy = "Newest"
+)
+
 // ImageSelector defines label selectors for looking up images.
 type ImageSelector struct {
 	// MatchLabels is a map of key/value pairs.
 	//
 	//+kubebuilder:validation:MinProperties=1
 	MatchLabels map[string]string `json:"matchLabels"`
+
+	// ResolutionPolicy controls the lookup behavior.
+	// The default policy 'Exact' will raise an error if the selector resolves to more than 1 image.
+	// Use policy 'Newest' to select the newest image instead.
+	//
+	//+kubebuilder:default=`Exact`
+	//+optional
+	ResolutionPolicy ImageSelectorResolutionPolicy `json:"resolutionPolicy,omitempty"`
 
 	// UseMachineVersion indicates whether to use the parent Machine's version field to look up image names.
 	// Enabled by default.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachines.yaml
@@ -213,6 +213,16 @@ spec:
                             description: MatchLabels is a map of key/value pairs.
                             minProperties: 1
                             type: object
+                          resolutionPolicy:
+                            default: Exact
+                            description: |-
+                              ResolutionPolicy controls the lookup behavior.
+                              The default policy 'Exact' will raise an error if the selector resolves to more than 1 image.
+                              Use policy 'Newest' to select the newest image instead.
+                            enum:
+                            - Exact
+                            - Newest
+                            type: string
                           useMachineVersion:
                             default: true
                             description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudmachinetemplates.yaml
@@ -234,6 +234,16 @@ spec:
                                       pairs.
                                     minProperties: 1
                                     type: object
+                                  resolutionPolicy:
+                                    default: Exact
+                                    description: |-
+                                      ResolutionPolicy controls the lookup behavior.
+                                      The default policy 'Exact' will raise an error if the selector resolves to more than 1 image.
+                                      Use policy 'Newest' to select the newest image instead.
+                                    enum:
+                                    - Exact
+                                    - Newest
+                                    type: string
                                   useMachineVersion:
                                     default: true
                                     description: |-

--- a/internal/service/cloud/image.go
+++ b/internal/service/cloud/image.go
@@ -71,9 +71,13 @@ func (s *Service) lookupImageID(ctx context.Context, ms *scope.Machine) (string,
 		images = filterImagesByName(images, version)
 	}
 
+	if len(images) == 0 {
+		return "", imageMatchError{selector: imageSpec.Selector}
+	}
+
 	switch imageSpec.Selector.ResolutionPolicy {
 	case infrav1.ResolutionPolicyExact:
-		if len(images) != 1 {
+		if len(images) > 1 {
 			return "", imageMatchError{imageIDs: getImageIDs(images), selector: imageSpec.Selector}
 		}
 	case infrav1.ResolutionPolicyNewest:
@@ -81,10 +85,6 @@ func (s *Service) lookupImageID(ctx context.Context, ms *scope.Machine) (string,
 			// swap lhs and rhs to produce reverse order
 			return rhs.Metadata.CreatedDate.Compare(lhs.Metadata.CreatedDate.Time)
 		})
-	}
-
-	if len(images) == 0 {
-		return "", imageMatchError{selector: imageSpec.Selector}
 	}
 
 	return ptr.Deref(images[0].GetId(), ""), nil

--- a/templates/cluster-template-auto-image.yaml
+++ b/templates/cluster-template-auto-image.yaml
@@ -291,6 +291,7 @@ spec:
       disk:
         image:
           selector:
+            resolutionPolicy: ${IONOSCLOUD_IMAGE_RESOLUTION_POLICY:-Newest}
             matchLabels:
               ${IONOSCLOUD_IMAGE_LABEL_KEY}: ${IONOSCLOUD_IMAGE_LABEL_VALUE}
 ---
@@ -336,6 +337,7 @@ spec:
       disk:
         image:
           selector:
+            resolutionPolicy: ${IONOSCLOUD_IMAGE_RESOLUTION_POLICY:-Newest}
             matchLabels:
               ${IONOSCLOUD_IMAGE_LABEL_KEY}: ${IONOSCLOUD_IMAGE_LABEL_VALUE}
 ---

--- a/test/e2e/capic_test.go
+++ b/test/e2e/capic_test.go
@@ -121,3 +121,17 @@ var _ = Describe("Should be able to create a cluster with 1 control-plane using 
 		}
 	})
 })
+
+var _ = Describe("Should be able to create a cluster with 1 control-plane and 2 workers using an image selector", func() {
+	capie2e.QuickStartSpec(ctx, func() capie2e.QuickStartSpecInput {
+		return capie2e.QuickStartSpecInput{
+			E2EConfig:             e2eConfig,
+			ClusterctlConfigPath:  clusterctlConfigPath,
+			BootstrapClusterProxy: bootstrapClusterProxy,
+			ArtifactFolder:        artifactFolder,
+			SkipCleanup:           skipCleanup,
+			Flavor:                ptr.To("image-selector"),
+			PostNamespaceCreated:  cloudEnv.createCredentialsSecretPNC,
+		}
+	})
+})

--- a/test/e2e/capic_test.go
+++ b/test/e2e/capic_test.go
@@ -92,6 +92,7 @@ var _ = Describe("Should be able to create a cluster with 1 control-plane and 1 
 			E2EConfig:             e2eConfig,
 			ClusterctlConfigPath:  clusterctlConfigPath,
 			BootstrapClusterProxy: bootstrapClusterProxy,
+			Flavor:                "image-selector",
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
 			PostNamespaceCreated:  cloudEnv.createCredentialsSecretPNC,
@@ -118,20 +119,6 @@ var _ = Describe("Should be able to create a cluster with 1 control-plane using 
 				desired := os.Getenv("ADDITIONAL_IPS")
 				Expect(nic.IPv4Addresses).To(ContainElement(desired))
 			},
-		}
-	})
-})
-
-var _ = Describe("Should be able to create a cluster with 1 control-plane and 2 workers using an image selector", func() {
-	capie2e.QuickStartSpec(ctx, func() capie2e.QuickStartSpecInput {
-		return capie2e.QuickStartSpecInput{
-			E2EConfig:             e2eConfig,
-			ClusterctlConfigPath:  clusterctlConfigPath,
-			BootstrapClusterProxy: bootstrapClusterProxy,
-			ArtifactFolder:        artifactFolder,
-			SkipCleanup:           skipCleanup,
-			Flavor:                ptr.To("image-selector"),
-			PostNamespaceCreated:  cloudEnv.createCredentialsSecretPNC,
 		}
 	})
 })

--- a/test/e2e/config/ionoscloud.yaml
+++ b/test/e2e/config/ionoscloud.yaml
@@ -65,12 +65,13 @@ providers:
           - sourcePath: "../../../metadata.yaml"
           - sourcePath: "../data/infrastructure-ionoscloud/cluster-template.yaml"
           - sourcePath: "../data/infrastructure-ionoscloud/cluster-template-ipam.yaml"
+          - sourcePath: "../data/infrastructure-ionoscloud/cluster-template-image-selector.yaml"
 variables:
   # Default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different Prow jobs e.g. each one with a K8s version permutation.
   # The following Kubernetes versions should be the latest versions with already published kindest/node images.
   # This avoids building node images in the default case which improves the test duration significantly.
-  KUBERNETES_VERSION: "v1.29.2"
+  KUBERNETES_VERSION: "v1.30.6"
   CNI: "./data/cni/calico.yaml"
   KUBETEST_CONFIGURATION: "./data/kubetest/conformance.yaml"
   CLUSTER_NAME: "e2e-cluster-${RANDOM}"

--- a/test/e2e/data/infrastructure-ionoscloud/cluster-template-image-selector.yaml
+++ b/test/e2e/data/infrastructure-ionoscloud/cluster-template-image-selector.yaml
@@ -1,0 +1,454 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  labels:
+    cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
+    cni: "${CLUSTER_NAME}-crs-0"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: IonosCloudCluster
+    name: "${CLUSTER_NAME}"
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: IonosCloudCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+spec:
+  controlPlaneEndpoint:
+    host: ${CONTROL_PLANE_ENDPOINT_HOST:-${CONTROL_PLANE_ENDPOINT_IP}}
+    port: ${CONTROL_PLANE_ENDPOINT_PORT:-6443}
+  location: ${CONTROL_PLANE_ENDPOINT_LOCATION}
+  credentialsRef:
+    name: "ionoscloud-credentials"
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: IonosCloudMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+      name: "${CLUSTER_NAME}-control-plane"
+  kubeadmConfigSpec:
+    users:
+      - name: root
+        sshAuthorizedKeys: [${IONOSCLOUD_MACHINE_SSH_KEYS}]
+    ntp:
+      enabled: true
+      servers:
+        - 0.de.pool.ntp.org
+        - 1.de.pool.ntp.org
+        - 2.de.pool.ntp.org
+        - 3.de.pool.ntp.org
+    files:
+      - path: /etc/ssh/sshd_config.d/ssh-audit_hardening.conf
+        owner: root:root
+        permissions: '0644'
+        content: |
+          # Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com
+          # hardening guide.
+          KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,gss-curve25519-sha256-,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+          Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+          MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+          HostKeyAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+          CASignatureAlgorithms sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+          GSSAPIKexAlgorithms gss-curve25519-sha256-,gss-group16-sha512-
+          HostbasedAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256
+          PubkeyAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256
+      - path: /etc/sysctl.d/k8s.conf
+        content: |
+          fs.inotify.max_user_watches = 65536
+          net.netfilter.nf_conntrack_max = 1000000
+      - path: /etc/modules-load.d/k8s.conf
+        content: |
+          ip_vs
+          ip_vs_rr
+          ip_vs_wrr
+          ip_vs_sh
+          ip_vs_sed
+      # Crictl config
+      - path: /etc/crictl.yaml
+        content: |
+          runtime-endpoint: unix:///run/containerd/containerd.sock
+          timeout: 10
+      - path: /etc/kubernetes/manifests/kube-vip.yaml
+        owner: root:root
+        content: |
+          apiVersion: v1
+          kind: Pod
+          metadata:
+            name: kube-vip
+            namespace: kube-system
+          spec:
+            containers:
+            - args:
+              - manager
+              env:
+              - name: cp_enable
+                value: "true"
+              - name: vip_interface
+                value: ${VIP_NETWORK_INTERFACE=""}
+              - name: address
+                value: ${CONTROL_PLANE_ENDPOINT_IP}
+              - name: port
+                value: "${CONTROL_PLANE_ENDPOINT_PORT:-6443}"
+              - name: vip_arp
+                value: "true"
+              - name: vip_leaderelection
+                value: "true"
+              - name: vip_leaseduration
+                value: "15"
+              - name: vip_renewdeadline
+                value: "10"
+              - name: vip_retryperiod
+                value: "2"
+              image: ghcr.io/kube-vip/kube-vip:v0.7.1
+              imagePullPolicy: IfNotPresent
+              name: kube-vip
+              resources: {}
+              securityContext:
+                capabilities:
+                  add:
+                  - NET_ADMIN
+                  - NET_RAW
+              volumeMounts:
+              - mountPath: /etc/kubernetes/admin.conf
+                name: kubeconfig
+            hostAliases:
+            - hostnames:
+              - kubernetes
+              - localhost
+              ip: 127.0.0.1
+            hostNetwork: true
+            volumes:
+            - hostPath:
+                path: /etc/kubernetes/admin.conf
+                type: FileOrCreate
+              name: kubeconfig
+          status: {}
+      - path: /etc/kube-vip-prepare.sh
+        content: |
+          #!/bin/bash
+
+          # Copyright 2020 The Kubernetes Authors.
+          #
+          # Licensed under the Apache License, Version 2.0 (the "License");
+          # you may not use this file except in compliance with the License.
+          # You may obtain a copy of the License at
+          #
+          #     http://www.apache.org/licenses/LICENSE-2.0
+          #
+          # Unless required by applicable law or agreed to in writing, software
+          # distributed under the License is distributed on an "AS IS" BASIS,
+          # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+          # See the License for the specific language governing permissions and
+          # limitations under the License.
+
+          set -e
+
+          # Configure the workaround required for kubeadm init with kube-vip:
+          # xref: https://github.com/kube-vip/kube-vip/issues/684
+
+          # Nothing to do for kubernetes < v1.29
+          KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+          if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+            exit 0
+          fi
+
+          IS_KUBEADM_INIT="false"
+
+          # cloud-init kubeadm init
+          if [[ -f /run/kubeadm/kubeadm.yaml ]]; then
+            IS_KUBEADM_INIT="true"
+          fi
+
+          # ignition kubeadm init
+          if [[ -f /etc/kubeadm.sh ]] && grep -q -e "kubeadm init" /etc/kubeadm.sh; then
+            IS_KUBEADM_INIT="true"
+          fi
+
+          if [[ "$IS_KUBEADM_INIT" == "true" ]]; then
+            sed -i 's#path: /etc/kubernetes/admin.conf#path: /etc/kubernetes/super-admin.conf#' \
+              /etc/kubernetes/manifests/kube-vip.yaml
+          fi
+        owner: root:root
+        permissions: "0700"
+
+      # CSI Metadata config
+      - content: |
+          {
+            "datacenter-id": "${IONOSCLOUD_DATACENTER_ID}"
+          }
+        owner: root:root
+        path: /etc/ie-csi/cfg.json
+        permissions: '0644'
+
+      - content: |
+          #!/bin/bash
+          set -e
+          
+          # Nothing to do for kubernetes < v1.29
+          KUBEADM_MINOR="$(kubeadm version -o short | cut -d '.' -f 2)"
+          if [[ "$KUBEADM_MINOR" -lt "29" ]]; then
+            exit 0
+          fi
+          
+          NODE_IPv4_ADDRESS=$(ip -j addr show dev ens6 | jq -r '.[].addr_info[] | select(.family == "inet") | select(.scope=="global") | select(.dynamic) | .local')
+          if [[ $NODE_IPv4_ADDRESS ]]; then
+            sed -i '$ s/$/ --node-ip '"$NODE_IPv4_ADDRESS"'/' /etc/default/kubelet
+          fi
+          # IPv6 currently not set, the ip is not set then this runs. Needs to be waited for.
+          NODE_IPv6_ADDRESS=$(ip -j addr show dev ens6 | jq -r '.[].addr_info[] | select(.family == "inet6") | select(.scope=="global") | .local')
+          if [[ $NODE_IPv6_ADDRESS ]]; then
+            sed -i '$ s/$/ --node-ip '"$NODE_IPv6_ADDRESS"'/' /etc/default/kubelet
+          fi
+        owner: root:root
+        path: /etc/set-node-ip.sh
+        permissions: '0700'
+
+    preKubeadmCommands:
+      - systemctl restart systemd-networkd.service systemd-modules-load.service systemd-journald containerd
+      # disable swap
+      - swapoff -a
+      - sed -i '/ swap / s/^/#/' /etc/fstab
+      - sysctl --system
+      - /etc/kube-vip-prepare.sh
+      # workaround 1.29 IP issue
+      - /etc/set-node-ip.sh
+    postKubeadmCommands:
+      - >
+        sed -i 's#path: /etc/kubernetes/super-admin.conf#path: /etc/kubernetes/admin.conf#' \
+        /etc/kubernetes/manifests/kube-vip.yaml
+      - >
+        systemctl disable --now udisks2 multipathd motd-news.timer fwupd-refresh.timer
+        packagekit ModemManager snapd snapd.socket snapd.apparmor snapd.seeded
+      # INFO(schegi-ionos): We decided to not remove this for now, since removing this would require the ccm to be installed for cluster-api
+      # to continue after the first node.
+      - export system_uuid=$(kubectl --kubeconfig /etc/kubernetes/kubelet.conf get node $(hostname) -ojsonpath='{..systemUUID }')
+      - >
+        kubectl --kubeconfig /etc/kubernetes/kubelet.conf
+        patch node $(hostname)
+        --type strategic -p '{"spec": {"providerID": "ionos://'$${system_uuid}'"}}'
+      - rm /etc/ssh/ssh_host_*
+      - ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ""
+      - ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+      - sed -i 's/^\#HostKey \/etc\/ssh\/ssh_host_\(rsa\|ed25519\)_key$/HostKey \/etc\/ssh\/ssh_host_\1_key/g' /etc/ssh/sshd_config
+      - awk '$5 >= 3071' /etc/ssh/moduli > /etc/ssh/moduli.safe
+      - mv /etc/ssh/moduli.safe /etc/ssh/moduli
+      - iptables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --set
+      - iptables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --update --seconds 10 --hitcount 10 -j DROP
+      - ip6tables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --set
+      - ip6tables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --update --seconds 10 --hitcount 10 -j DROP
+      - apt-get update
+      - DEBIAN_FRONTEND=noninteractive apt-get install -q -y netfilter-persistent iptables-persistent
+      - service netfilter-persistent save
+      - systemctl restart sshd
+    initConfiguration:
+      localAPIEndpoint:
+        bindPort: ${CONTROL_PLANE_ENDPOINT_PORT:-6443}
+      nodeRegistration:
+        kubeletExtraArgs:
+          # use cloud-provider: external when using a CCM
+          cloud-provider: ""
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: unix:///run/containerd/containerd.sock
+        kubeletExtraArgs:
+          # use cloud-provider: external when using a CCM
+          cloud-provider: ""
+  version: "${KUBERNETES_VERSION}"
+---
+kind: IonosCloudMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      datacenterID: ${IONOSCLOUD_DATACENTER_ID}
+      numCores: ${IONOSCLOUD_MACHINE_NUM_CORES:-4}
+      memoryMB: ${IONOSCLOUD_MACHINE_MEMORY_MB:-8192}
+      disk:
+        image:
+          selector:
+            resolutionPolicy: Newest
+            matchLabels:
+              ${IONOSCLOUD_IMAGE_LABEL_KEY:-e2etest}: ${IONOSCLOUD_IMAGE_LABEL_VALUE:-capic}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-workers"
+  labels:
+    cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
+        node-role.kubernetes.io/node: ""
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-worker"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-worker"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: IonosCloudMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: IonosCloudMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-worker"
+spec:
+  template:
+    spec:
+      datacenterID: ${IONOSCLOUD_DATACENTER_ID}
+      numCores: ${IONOSCLOUD_MACHINE_NUM_CORES:-2}
+      memoryMB: ${IONOSCLOUD_MACHINE_MEMORY_MB:-4096}
+      disk:
+        image:
+          selector:
+            resolutionPolicy: Newest
+            matchLabels:
+              ${IONOSCLOUD_IMAGE_LABEL_KEY:-e2etest}: ${IONOSCLOUD_IMAGE_LABEL_VALUE:-capic}
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-worker"
+spec:
+  template:
+    spec:
+      users:
+        - name: root
+          sshAuthorizedKeys: [${IONOSCLOUD_MACHINE_SSH_KEYS}]
+      ntp:
+        enabled: true
+        servers:
+          - 0.de.pool.ntp.org
+          - 1.de.pool.ntp.org
+          - 2.de.pool.ntp.org
+          - 3.de.pool.ntp.org
+      files:
+        - path: /etc/ssh/sshd_config.d/ssh-audit_hardening.conf
+          owner: root:root
+          permissions: '0644'
+          content: |
+            # Restrict key exchange, cipher, and MAC algorithms, as per sshaudit.com
+            # hardening guide.
+            KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,gss-curve25519-sha256-,diffie-hellman-group16-sha512,gss-group16-sha512-,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256
+            Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+            MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+            HostKeyAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+            CASignatureAlgorithms sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512,rsa-sha2-256
+            GSSAPIKexAlgorithms gss-curve25519-sha256-,gss-group16-sha512-
+            HostbasedAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256
+            PubkeyAcceptedAlgorithms sk-ssh-ed25519-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,sk-ssh-ed25519@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-256
+        - path: /etc/sysctl.d/k8s.conf
+          content: |
+            fs.inotify.max_user_watches = 65536
+            net.netfilter.nf_conntrack_max = 1000000
+        - path: /etc/modules-load.d/k8s.conf
+          content: |
+            ip_vs
+            ip_vs_rr
+            ip_vs_wrr
+            ip_vs_sh
+            ip_vs_sed
+        # Crictl config
+        - path: /etc/crictl.yaml
+          content: |
+            runtime-endpoint: unix:///run/containerd/containerd.sock
+            timeout: 10
+        # CSI Metadata config
+        - content: |
+            {
+              "datacenter-id": "${IONOSCLOUD_DATACENTER_ID}"
+            }
+          owner: root:root
+          path: /etc/ie-csi/cfg.json
+          permissions: '0644'
+      preKubeadmCommands:
+        - systemctl restart systemd-networkd.service systemd-modules-load.service systemd-journald containerd
+        # disable swap
+        - swapoff -a
+        - sed -i '/ swap / s/^/#/' /etc/fstab
+        - sysctl --system
+      postKubeadmCommands:
+        - >
+          systemctl disable --now udisks2 multipathd motd-news.timer fwupd-refresh.timer
+          packagekit ModemManager snapd snapd.socket snapd.apparmor snapd.seeded
+        # INFO(schegi-ionos): We decided to not remove this for now, since removing this would require the ccm to be
+        # installed for cluster-api to continue after the first node.
+        - export system_uuid=$(kubectl --kubeconfig /etc/kubernetes/kubelet.conf get node $(hostname) -ojsonpath='{..systemUUID }')
+        - >
+          kubectl --kubeconfig /etc/kubernetes/kubelet.conf
+          patch node $(hostname)
+          --type strategic -p '{"spec": {"providerID": "ionos://'$${system_uuid}'"}}'
+        - rm /etc/ssh/ssh_host_*
+        - ssh-keygen -t rsa -b 4096 -f /etc/ssh/ssh_host_rsa_key -N ""
+        - ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -N ""
+        - sed -i 's/^\#HostKey \/etc\/ssh\/ssh_host_\(rsa\|ed25519\)_key$/HostKey \/etc\/ssh\/ssh_host_\1_key/g' /etc/ssh/sshd_config
+        - awk '$5 >= 3071' /etc/ssh/moduli > /etc/ssh/moduli.safe
+        - mv /etc/ssh/moduli.safe /etc/ssh/moduli
+        - iptables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --set
+        - iptables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --update --seconds 10 --hitcount 10 -j DROP
+        - ip6tables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --set
+        - ip6tables -I INPUT -p tcp --dport 22 -m state --state NEW -m recent --update --seconds 10 --hitcount 10 -j DROP
+        - apt-get update
+        - DEBIAN_FRONTEND=noninteractive apt-get install -q -y netfilter-persistent iptables-persistent
+        - service netfilter-persistent save
+        - systemctl restart sshd
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            # use cloud-provider: external when using a CCM
+            cloud-provider: ""
+          criSocket: unix:///run/containerd/containerd.sock
+---
+# ConfigMap object referenced by the ClusterResourceSet object and with
+# the CNI resource defined in the test config file
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "cni-${CLUSTER_NAME}-crs-0"
+data: ${CNI_RESOURCES}
+---
+# ClusterResourceSet object with
+# a selector that targets all the Cluster with label cni=${CLUSTER_NAME}-crs-0
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: '${CLUSTER_NAME}'
+  name:  "${CLUSTER_NAME}-crs-0"
+spec:
+  strategy: ApplyOnce
+  clusterSelector:
+    matchLabels:
+      cni: "${CLUSTER_NAME}-crs-0"
+  resources:
+    - name: "cni-${CLUSTER_NAME}-crs-0"
+      kind: ConfigMap

--- a/test/e2e/env_test.go
+++ b/test/e2e/env_test.go
@@ -79,7 +79,7 @@ func (e *ionosCloudEnv) setup() {
 }
 
 func (e *ionosCloudEnv) teardown() {
-	if !skipCleanup {
+	if !skipCleanup && e.api != nil {
 		By("Deleting environment resources")
 
 		By("Requesting the deletion of the data center")

--- a/test/e2e/k8s_conformance_test.go
+++ b/test/e2e/k8s_conformance_test.go
@@ -34,6 +34,7 @@ var _ = Describe("When testing K8S conformance", Label("Conformance"), func() {
 			BootstrapClusterProxy: bootstrapClusterProxy,
 			ArtifactFolder:        artifactFolder,
 			SkipCleanup:           skipCleanup,
+			Flavor:                "image-selector",
 			PostNamespaceCreated:  cloudEnv.createCredentialsSecretPNC,
 		}
 	})


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

Users might want to update VM images without changing the Kubernetes version.
When using an image selector this currently requires removing labels from the old image and adding them to the new one.
I wanted to provide a better solution for this.

**Issue #, if available:**

**Description of changes:**

Add a new field `resolutionPolicy` to the `imageSelector`. Currently only two values are allowed `Exact` and `Newest`.
`Exact` maps to the current behavior and is the default.
`Newest` will use the newest entry (determined by `createdDate`) from the set of matching images.

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [x] Unit Tests added
- [x] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
