### PR TITLE
fix: Allow control plane endpoint updates with empty location

### DIFF
--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -34,8 +34,6 @@ const (
 	IonosCloudClusterKind = "IonosCloudCluster"
 )
 
-//+kubebuilder:validation:XValidation:rule="self.controlPlaneEndpoint.host == '' || has(self.location)",message="location is required when controlPlaneEndpoint.host is set"
-
 // IonosCloudClusterSpec defines the desired state of IonosCloudCluster.
 type IonosCloudClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.

--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -34,6 +34,8 @@ const (
 	IonosCloudClusterKind = "IonosCloudCluster"
 )
 
+//+kubebuilder:validation:XValidation:rule="!has(self.loadBalancerProviderRef) || has(self.location)",message="location is required when loadBalancerProviderRef is set"
+
 // IonosCloudClusterSpec defines the desired state of IonosCloudCluster.
 type IonosCloudClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.

--- a/api/v1alpha1/ionoscloudcluster_types_test.go
+++ b/api/v1alpha1/ionoscloudcluster_types_test.go
@@ -86,14 +86,15 @@ var _ = Describe("IonosCloudCluster", func() {
 			Expect(k8sClient.Create(context.Background(), cluster)).
 				Should(MatchError(ContainSubstring("credentialsRef.name must be provided")))
 		})
-		It("should not allow creating clusters with empty location when ControlPlaneEndpoint host is set", func() {
+		It("should not allow creating clusters with empty location when loadBalancerProviderRef is set", func() {
 			cluster := defaultCluster()
 			cluster.Spec.Location = ""
 			Expect(k8sClient.Create(context.Background(), cluster)).
-				Should(MatchError(ContainSubstring("location is required when controlPlaneEndpoint.host is set")))
+				Should(MatchError(ContainSubstring("location is required when loadBalancerProviderRef is set")))
 		})
 		It("should allow creating clusters with empty location when ControlPlaneEndpoint host is not set", func() {
 			cluster := defaultCluster()
+			cluster.Spec.LoadBalancerProviderRef = nil
 			cluster.Spec.Location = ""
 			cluster.Spec.ControlPlaneEndpoint.Host = ""
 			Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())

--- a/api/v1alpha1/ionoscloudcluster_types_test.go
+++ b/api/v1alpha1/ionoscloudcluster_types_test.go
@@ -92,7 +92,7 @@ var _ = Describe("IonosCloudCluster", func() {
 			Expect(k8sClient.Create(context.Background(), cluster)).
 				Should(MatchError(ContainSubstring("location is required when loadBalancerProviderRef is set")))
 		})
-		It("should allow creating clusters with empty location when ControlPlaneEndpoint host is not set", func() {
+		It("should allow creating clusters with empty location and ControlPlaneEndpoint host when loadBalancerProviderRef is not set", func() {
 			cluster := defaultCluster()
 			cluster.Spec.LoadBalancerProviderRef = nil
 			cluster.Spec.Location = ""
@@ -125,6 +125,16 @@ var _ = Describe("IonosCloudCluster", func() {
 
 				cluster.Spec.ControlPlaneEndpoint.Port = 1234
 				cluster.Spec.ControlPlaneEndpoint.Host = "example.org"
+				Expect(k8sClient.Update(context.Background(), cluster)).To(Succeed())
+			})
+			It("should not fail when when location is empty and loadBalancerProviderRef is not set", func() {
+				cluster := defaultCluster()
+				cluster.Spec.LoadBalancerProviderRef = nil
+				cluster.Spec.Location = ""
+				cluster.Spec.ControlPlaneEndpoint.Host = ""
+				Expect(k8sClient.Create(context.Background(), cluster)).To(Succeed())
+
+				cluster.Spec.ControlPlaneEndpoint = defaultCluster().Spec.ControlPlaneEndpoint
 				Expect(k8sClient.Update(context.Background(), cluster)).To(Succeed())
 			})
 		})

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -124,6 +124,9 @@ spec:
             required:
             - credentialsRef
             type: object
+            x-kubernetes-validations:
+            - message: location is required when loadBalancerProviderRef is set
+              rule: '!has(self.loadBalancerProviderRef) || has(self.location)'
           status:
             description: IonosCloudClusterStatus defines the observed state of IonosCloudCluster.
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclusters.yaml
@@ -124,9 +124,6 @@ spec:
             required:
             - credentialsRef
             type: object
-            x-kubernetes-validations:
-            - message: location is required when controlPlaneEndpoint.host is set
-              rule: self.controlPlaneEndpoint.host == '' || has(self.location)
           status:
             description: IonosCloudClusterStatus defines the observed state of IonosCloudCluster.
             properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
@@ -116,10 +116,6 @@ spec:
                     required:
                     - credentialsRef
                     type: object
-                    x-kubernetes-validations:
-                    - message: location is required when controlPlaneEndpoint.host
-                        is set
-                      rule: self.controlPlaneEndpoint.host == '' || has(self.location)
                 required:
                 - spec
                 type: object

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_ionoscloudclustertemplates.yaml
@@ -116,6 +116,10 @@ spec:
                     required:
                     - credentialsRef
                     type: object
+                    x-kubernetes-validations:
+                    - message: location is required when loadBalancerProviderRef is
+                        set
+                      rule: '!has(self.loadBalancerProviderRef) || has(self.location)'
                 required:
                 - spec
                 type: object


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**

This validation is blocking successful reconciliation of kamaji resources under certain circumstances.
I should've noticed while testing it the first time, but I think my test data was limited to a single scenario.

**Issue #, if available:**

**Description of changes:**

Change validation to check whether the loadBalancerProviderRef is set in combination with the location.
This is needed for kamaji to successfully update the control plane endpoint.

**Special notes for your reviewer:**

I tested this by updating the CRD manually and seeing reconciliation succeed.

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [x] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)
