### PR TITLE
Solve CVE: Bump GO v1.24.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.4 AS builder
+FROM golang:1.24 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ionos-cloud/cluster-api-provider-ionoscloud
 
-go 1.24.3
+go 1.24.5
 
 require (
 	github.com/go-logr/logr v1.4.2
@@ -120,7 +120,7 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
+	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/term v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.2.0/go.mod h1:KqCZLdyyvdV855qA2rE3GC2aiw5xGR5TEjj8smXukLY=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
-golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
-golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
+golang.org/x/oauth2 v0.30.0 h1:dnDm7JmhM45NNpd8FDDeLhK6FwqbOf4MLCM9zb1BOHI=
+golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKlU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.24.3
+go 1.24.5
 
 require (
 	github.com/golangci/golangci-lint v1.63.4


### PR DESCRIPTION
This PR bumps Go in order to solve the follwing CVEs:

```
| sync-harbor.infra.cluster.ionos.com/mirror/ghcr.io/ionos-cloud/cluster-api-provider-ionoscloud:v0.6.1 | manager | gobinary | CVE-2025-22868 | ghsa | 7.5 |
| sync-harbor.infra.cluster.ionos.com/mirror/ghcr.io/ionos-cloud/cluster-api-provider-ionoscloud:v0.6.1 | manager | gobinary | CVE-2025-22868 | redhat | 7.5 |
| sync-harbor.infra.cluster.ionos.com/mirror/ghcr.io/ionos-cloud/cluster-api-provider-ionoscloud:v0.6.1 | manager | gobinary | CVE-2025-22874 | bitnami | 7.5 |
| sync-harbor.infra.cluster.ionos.com/mirror/ghcr.io/ionos-cloud/cluster-api-provider-ionoscloud:v0.6.1 | manager | gobinary | CVE-2025-22874 | redhat | 7.5 |
```