### PR TITLE
🌱 Bump golang from 1.24.4 to 1.24.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24.4 AS builder
+FROM golang:1.24.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
Cherry-pick of https://github.com/ionos-cloud/cluster-api-provider-ionoscloud/pull/297
