### PR TITLE
fix(scope): remove MachineProvisionedCondition from WithOwnedV1Beta1Conditions

### DIFF
--- a/scope/machine.go
+++ b/scope/machine.go
@@ -191,7 +191,6 @@ func (m *Machine) PatchObject() error {
 		m.IonosMachine,
 		patch.WithOwnedV1Beta1Conditions{Conditions: []clusterv1.ConditionType{
 			clusterv1.ReadyCondition,
-			infrav1.MachineProvisionedCondition,
 		}},
 		patch.WithOwnedConditions{Conditions: []string{
 			string(clusterv1.ReadyCondition),


### PR DESCRIPTION
## Summary

- Remove `infrav1.MachineProvisionedCondition` from `patch.WithOwnedV1Beta1Conditions` in `PatchObject`
- No production code writes `MachineProvisionedCondition` as a v1beta1 condition; since CAPI v1.11, `FinalizeMachineProvisioning` uses `conditions.Set` (v1beta2 API) exclusively
- Listing it in `WithOwnedV1Beta1Conditions` signalled false ownership and prevented the patch helper from cleaning up stale pre-upgrade v1beta1 conditions

## Test plan

- [ ] Verify `go build ./scope/...` compiles cleanly
- [ ] Verify no test failures in `go test ./scope/...`
- [ ] Confirm `WithOwnedV1Beta1Conditions` still contains `clusterv1.ReadyCondition` (the only v1beta1-managed condition)
- [ ] Confirm `WithOwnedConditions` (v1beta2) still contains both `ReadyCondition` and `MachineProvisionedCondition`

🤖 Generated with [Claude Code](https://claude.com/claude-code)