### PR TITLE
fix(ipam): guard against nil APIGroup when constructing IPPoolReference

### DIFF
--- a/internal/service/k8s/ipam.go
+++ b/internal/service/k8s/ipam.go
@@ -269,12 +269,13 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 		return nil
 	}
 
-	ipPoolRef := ipamv1.IPPoolReference{
-		Name: poolRef.Name,
-		Kind: poolRef.Kind,
+	if poolRef.APIGroup == nil {
+		return fmt.Errorf("pool reference for IPAddressClaim %q has no APIGroup", claimRef.Name)
 	}
-	if poolRef.APIGroup != nil {
-		ipPoolRef.APIGroup = *poolRef.APIGroup
+	ipPoolRef := ipamv1.IPPoolReference{
+		Name:     poolRef.Name,
+		Kind:     poolRef.Kind,
+		APIGroup: *poolRef.APIGroup,
 	}
 
 	desired := &ipamv1.IPAddressClaim{


### PR DESCRIPTION
## Summary

- `CreateIPAddressClaim` previously constructed an `ipamv1.IPPoolReference` from `*corev1.TypedLocalObjectReference` without checking whether `poolRef.APIGroup` was nil, leaving `IPPoolReference.APIGroup` as an empty string
- `IPPoolReference.APIGroup` is `+required` with `MinLength=1`; an empty value causes the API server to reject the `IPAddressClaim` with a CEL validation error, permanently stalling IP allocation with no clear root-cause pointer
- Fix adds an early `nil` guard that returns a descriptive error, and inlines the pointer dereference in the struct literal

## Test plan

- [ ] Unit tests for `CreateIPAddressClaim` pass with a nil `APIGroup` returning the expected error
- [ ] Unit tests for `CreateIPAddressClaim` pass with a non-nil `APIGroup` creating the claim correctly
- [ ] `go build ./internal/service/k8s/...` compiles without errors
- [ ] E2E smoke: machine with a valid IPAM pool still gets an IP address

🤖 Generated with [Claude Code](https://claude.com/claude-code)