### PR TITLE
fix(scope): patch cluster object even when SetSummaryCondition returns an error

### DIFF
--- a/scope/cluster.go
+++ b/scope/cluster.go
@@ -202,15 +202,14 @@ func (c *Cluster) DeleteCurrentRequestByDatacenter(datacenterID string) {
 // PatchObject will apply all changes from the IonosCloudCluster.
 // It will also make sure to patch the status subresource.
 func (c *Cluster) PatchObject() error {
-	// always set the ready condition summary
-	if err := conditions.SetSummaryCondition(
+	// always set the ready condition summary; capture the error but do not return early —
+	// the patch must be attempted regardless (see NOTE below).
+	summaryErr := conditions.SetSummaryCondition(
 		c.IonosCluster,
 		c.IonosCluster,
 		string(clusterv1.ReadyCondition),
 		conditions.ForConditionTypes{string(infrav1.IonosCloudClusterReady)},
-	); err != nil {
-		return err
-	}
+	)
 
 	// NOTE(piepmatz): We don't accept and forward a context here. This is on purpose: Even if a reconciliation is
 	//  aborted, we want to make sure that the final patch is applied. Reusing the context from the reconciliation
@@ -218,7 +217,7 @@ func (c *Cluster) PatchObject() error {
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
-	return c.patchHelper.Patch(timeoutCtx, c.IonosCluster,
+	if patchErr := c.patchHelper.Patch(timeoutCtx, c.IonosCluster,
 		patch.WithOwnedV1Beta1Conditions{
 			Conditions: []clusterv1.ConditionType{clusterv1.ReadyCondition},
 		},
@@ -228,7 +227,10 @@ func (c *Cluster) PatchObject() error {
 				string(infrav1.IonosCloudClusterReady),
 			},
 		},
-	)
+	); patchErr != nil {
+		return patchErr
+	}
+	return summaryErr
 }
 
 // Finalize will make sure to apply a patch to the current IonosCloudCluster.


### PR DESCRIPTION
## Summary

- The CAPI v1.11 upgrade replaced `conditions.SetSummary` (void return) with `conditions.SetSummaryCondition` (returns error).
- The new code returned that error immediately, skipping `patchHelper.Patch` entirely — a silent regression.
- Fix captures the `SetSummaryCondition` error, always attempts the patch, and returns the first non-nil error (patch error takes precedence; summary condition error is returned only if patching succeeded).

## Details

Before CAPI v1.11, `conditions.SetSummary` returned nothing, so the patch always proceeded. After the upgrade, `conditions.SetSummaryCondition` returns an error, and the early-return guard meant any in-memory state changes made before `PatchObject` is called (deleted pending request entries, updated network info) were never flushed to the API server. On the next reconcile the controller would read stale data and potentially enter the wrong branch.

The comment directly below the old error check explicitly states the patch must happen even when reconciliation is aborted — making the intent clear.

## Test plan

- [ ] Unit tests for `PatchObject` pass
- [ ] Build succeeds (`go build ./...`)
- [ ] Verify `PatchObject` always calls `patchHelper.Patch` regardless of `SetSummaryCondition` result

🤖 Generated with [Claude Code](https://claude.com/claude-code)