### PR TITLE
fix(cluster-ctrl): add dedicated reason constant for IonosCloudClusterReady condition

### DIFF
--- a/api/v1alpha1/ionoscloudcluster_types.go
+++ b/api/v1alpha1/ionoscloudcluster_types.go
@@ -30,6 +30,9 @@ const (
 	// IonosCloudClusterReady is the condition for the IonosCloudCluster, which indicates that the cluster is ready.
 	IonosCloudClusterReady clusterv1.ConditionType = "ClusterReady"
 
+	// ClusterProvisionedReason documents that the IonosCloudCluster infrastructure has been fully provisioned and is ready.
+	ClusterProvisionedReason = "Provisioned"
+
 	// IonosCloudClusterKind is the string resource kind of the IonosCloudCluster resource.
 	IonosCloudClusterKind = "IonosCloudCluster"
 )

--- a/internal/controller/ionoscloudcluster_controller.go
+++ b/internal/controller/ionoscloudcluster_controller.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -172,7 +173,12 @@ func (r *IonosCloudClusterReconciler) reconcileNormal(
 		}
 	}
 
-	conditions.MarkTrue(clusterScope.IonosCluster, infrav1.IonosCloudClusterReady)
+	conditions.Set(clusterScope.IonosCluster, &clusterv1.Condition{
+		Type:    infrav1.IonosCloudClusterReady,
+		Status:  corev1.ConditionTrue,
+		Reason:  infrav1.ClusterProvisionedReason,
+		Message: "IonosCloud cluster infrastructure is provisioned and ready",
+	})
 	clusterScope.IonosCluster.Status.Ready = true
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
## Summary

- Adds `ClusterProvisionedReason = "Provisioned"` constant to `api/v1alpha1/ionoscloudcluster_types.go`, following the naming convention already established for machine conditions (`WaitingForClusterInfrastructureReason`, `WaitingForBootstrapDataReason`)
- Replaces `conditions.MarkTrue(clusterScope.IonosCluster, infrav1.IonosCloudClusterReady)` in the cluster controller with `conditions.Set(...)` using the new constant as `Reason` and an explicit `Message`
- Eliminates the tautological `Reason="ClusterReady"` (same as the condition Type) that provided no diagnostic value when CAPI mirrors it into the parent Cluster's `InfrastructureReady` summary condition

## Test plan

- [ ] Unit tests pass: `go test ./internal/controller/...`
- [ ] Build compiles cleanly: `go build ./...`
- [ ] Verify that after reconciliation the `ClusterReady` condition on an `IonosCloudCluster` shows `Reason=Provisioned` and a human-readable `Message` in `kubectl describe ionoscloudcluster`

🤖 Generated with [Claude Code](https://claude.com/claude-code)