### PR TITLE
fix(server): add dedicated reason constant for MachineProvisioned condition

### DIFF
--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -47,6 +47,9 @@ const (
 	// creating the bootstrap data secret and store it in the Cluster API Machine.
 	WaitingForBootstrapDataReason = "WaitingForBootstrapData"
 
+	// MachineProvisionedReason documents that the IonosCloudMachine has been successfully provisioned.
+	MachineProvisionedReason = "Provisioned"
+
 	// CloudResourceConfigAuto is a constant to indicate that the cloud resource should be managed by the
 	// Cluster API provider implementation.
 	CloudResourceConfigAuto = "AUTO"

--- a/internal/service/cloud/server.go
+++ b/internal/service/cloud/server.go
@@ -155,9 +155,10 @@ func (*Service) FinalizeMachineProvisioning(_ context.Context, ms *scope.Machine
 	}
 	ms.IonosMachine.Status.Deprecated.V1Beta1.Ready = true //nolint:staticcheck // Intentionally setting deprecated field for v1beta1 backwards compatibility.
 	conditions.Set(ms.IonosMachine, metav1.Condition{
-		Type:   string(infrav1.MachineProvisionedCondition),
-		Status: metav1.ConditionTrue,
-		Reason: string(infrav1.MachineProvisionedCondition),
+		Type:    string(infrav1.MachineProvisionedCondition),
+		Status:  metav1.ConditionTrue,
+		Reason:  infrav1.MachineProvisionedReason,
+		Message: "Machine infrastructure is fully provisioned.",
 	})
 	return false, nil
 }


### PR DESCRIPTION
## Summary

- Adds a `MachineProvisionedReason = "Provisioned"` constant to `api/v1alpha1/ionoscloudmachine_types.go` alongside the existing `WaitingForClusterInfrastructureReason` and `WaitingForBootstrapDataReason` constants
- Updates `FinalizeMachineProvisioning` in `internal/service/cloud/server.go` to use `infrav1.MachineProvisionedReason` instead of recycling the condition Type string as its own Reason
- Adds an explicit `Message` field to the `conditions.Set` call for operator diagnostics

## Problem

`FinalizeMachineProvisioning` called `conditions.Set` with `Reason: string(infrav1.MachineProvisionedCondition)`, recycling the condition Type `"MachineProvisioned"` as its own Reason — a tautology. The CAPI v1beta2 contract requires Reason to be a distinct CamelCase word explaining *why* the condition holds. When CAPI mirrors this condition into the parent Machine's `InfrastructureReady` summary, operators see `Reason="MachineProvisioned"` — identical to the type — providing zero diagnostic information. Alert rules and tooling that filter by Reason cannot distinguish "provisioned" from "still provisioning" using this value.

## Test plan

- [ ] Unit tests pass: `go test ./api/v1alpha1/... ./internal/service/cloud/...`
- [ ] Full build passes: `go build ./...`
- [ ] Verify `FinalizeMachineProvisioning` sets `Reason="Provisioned"` and `Message="Machine infrastructure is fully provisioned."` on the `MachineProvisioned` condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)