### PR TITLE
fix(controllers): add Message to all conditions.Set calls

### DIFF
--- a/internal/controller/ionoscloudmachine_controller.go
+++ b/internal/controller/ionoscloudmachine_controller.go
@@ -303,9 +303,10 @@ func (*IonosCloudMachineReconciler) isInfrastructureReady(ctx context.Context, m
 	if ms.ClusterScope.Cluster.Status.Initialization.InfrastructureProvisioned == nil || !*ms.ClusterScope.Cluster.Status.Initialization.InfrastructureProvisioned {
 		log.Info("Cluster infrastructure is not ready yet")
 		conditions.Set(ms.IonosMachine, metav1.Condition{
-			Type:   string(infrav1.MachineProvisionedCondition),
-			Status: metav1.ConditionFalse,
-			Reason: infrav1.WaitingForClusterInfrastructureReason,
+			Type:    string(infrav1.MachineProvisionedCondition),
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.WaitingForClusterInfrastructureReason,
+			Message: "Waiting for IonosCloudCluster to have Initialized=true.",
 		})
 
 		return false
@@ -315,9 +316,10 @@ func (*IonosCloudMachineReconciler) isInfrastructureReady(ctx context.Context, m
 	if ms.Machine.Spec.Bootstrap.DataSecretName == nil {
 		log.Info("Bootstrap data secret is not available yet")
 		conditions.Set(ms.IonosMachine, metav1.Condition{
-			Type:   string(infrav1.MachineProvisionedCondition),
-			Status: metav1.ConditionFalse,
-			Reason: infrav1.WaitingForBootstrapDataReason,
+			Type:    string(infrav1.MachineProvisionedCondition),
+			Status:  metav1.ConditionFalse,
+			Reason:  infrav1.WaitingForBootstrapDataReason,
+			Message: "Waiting for bootstrap data secret to be available.",
 		})
 
 		return false


### PR DESCRIPTION
## Summary

- The CAPI v1.11 upgrade switched from `conditions.MarkFalse` (which required an explicit message string) to `conditions.Set(metav1.Condition{...})` where `Message` is optional
- Both WaitingFor conditions in `ionoscloudmachine_controller.go` were left with no `Message` field, causing blank diagnostic text in `kubectl describe`, dashboards, and alert output
- Adds concise, human-readable messages to the two affected `conditions.Set` calls: `WaitingForClusterInfrastructureReason` and `WaitingForBootstrapDataReason`

## Test plan

- [ ] `go build ./internal/controller/...` passes (verified locally)
- [ ] Verify `kubectl describe ionoscloudmachine` shows meaningful messages under the `MachineProvisioned` condition when a machine is waiting for cluster infrastructure or bootstrap data
- [ ] Confirm `conditions.SetSummaryCondition` propagates the messages into the parent Ready condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)