### PR TITLE
refactor(ipam): extract shared TypedLocalObjectReference→IPPoolReference conversion

### DIFF
--- a/internal/service/k8s/ipam.go
+++ b/internal/service/k8s/ipam.go
@@ -269,14 +269,6 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 		return nil
 	}
 
-	ipPoolRef := ipamv1.IPPoolReference{
-		Name: poolRef.Name,
-		Kind: poolRef.Kind,
-	}
-	if poolRef.APIGroup != nil {
-		ipPoolRef.APIGroup = *poolRef.APIGroup
-	}
-
 	desired := &ipamv1.IPAddressClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      claimRef.Name,
@@ -284,7 +276,7 @@ func (h *Helper) CreateIPAddressClaim(ctx context.Context, owner client.Object, 
 			Labels:    map[string]string{clusterv1.ClusterNameLabel: cluster},
 		},
 		Spec: ipamv1.IPAddressClaimSpec{
-			PoolRef: ipPoolRef,
+			PoolRef: toIPPoolRef(poolRef),
 		},
 	}
 	_, err = controllerutil.CreateOrUpdate(ctx, h.client, desired, func() error {
@@ -315,4 +307,18 @@ func (h *Helper) GetIPAddressClaim(ctx context.Context, key client.ObjectKey) (*
 	}
 
 	return out, nil
+}
+
+// toIPPoolRef converts a corev1.TypedLocalObjectReference to an ipamv1.IPPoolReference.
+// If APIGroup is nil it is left empty; callers that require a non-empty APIGroup must
+// validate poolRef before calling this function.
+func toIPPoolRef(ref *corev1.TypedLocalObjectReference) ipamv1.IPPoolReference {
+	r := ipamv1.IPPoolReference{
+		Name: ref.Name,
+		Kind: ref.Kind,
+	}
+	if ref.APIGroup != nil {
+		r.APIGroup = *ref.APIGroup
+	}
+	return r
 }

--- a/internal/service/k8s/ipam_test.go
+++ b/internal/service/k8s/ipam_test.go
@@ -320,7 +320,7 @@ func defaultIPv4Address(claim *ipamv1.IPAddressClaim, poolRef *corev1.TypedLocal
 		},
 		Spec: ipamv1.IPAddressSpec{
 			ClaimRef: ipamv1.IPAddressClaimReference{Name: claim.GetName()},
-			PoolRef:  toIPPoolReference(poolRef),
+			PoolRef:  toIPPoolRef(poolRef),
 			Address:  "10.0.0.2",
 			Prefix:   new(int32(16)),
 		},
@@ -336,7 +336,7 @@ func defaultIPv6Address(claim *ipamv1.IPAddressClaim, poolRef *corev1.TypedLocal
 		},
 		Spec: ipamv1.IPAddressSpec{
 			ClaimRef: ipamv1.IPAddressClaimReference{Name: claim.GetName()},
-			PoolRef:  toIPPoolReference(poolRef),
+			PoolRef:  toIPPoolRef(poolRef),
 			Address:  "2001:db8::",
 			Prefix:   new(int32(42)),
 		},
@@ -397,13 +397,3 @@ func defaultPrimaryIPv6Claim() *ipamv1.IPAddressClaim {
 	}
 }
 
-func toIPPoolReference(ref *corev1.TypedLocalObjectReference) ipamv1.IPPoolReference {
-	r := ipamv1.IPPoolReference{
-		Name: ref.Name,
-		Kind: ref.Kind,
-	}
-	if ref.APIGroup != nil {
-		r.APIGroup = *ref.APIGroup
-	}
-	return r
-}


### PR DESCRIPTION
## Summary

- The CAPI v1.11 upgrade introduced a manual three-field struct mapping from `corev1.TypedLocalObjectReference` to `ipamv1.IPPoolReference` in `CreateIPAddressClaim` (ipam.go) and an identical helper `toIPPoolReference` in ipam_test.go
- Extract the shared logic into a package-private `toIPPoolRef` function in ipam.go, accessible from both the production and test code (same package)
- Remove the duplicate `toIPPoolReference` from ipam_test.go and replace its two call sites with `toIPPoolRef`

## Test plan

- [x] `go build ./internal/service/k8s/...` passes
- [x] `go test ./internal/service/k8s/...` passes
- [x] `go vet ./internal/service/k8s/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)