### PR TITLE
fix(server): use SetV1Beta1Ready helper instead of inline nil-guards

### DIFF
--- a/api/v1alpha1/ionoscloudmachine_types.go
+++ b/api/v1alpha1/ionoscloudmachine_types.go
@@ -429,6 +429,17 @@ func (m *IonosCloudMachine) SetV1Beta1Conditions(conditions clusterv1.Conditions
 	m.Status.Deprecated.V1Beta1.Conditions = conditions
 }
 
+// SetV1Beta1Ready sets the deprecated v1beta1 ready field.
+func (m *IonosCloudMachine) SetV1Beta1Ready(ready bool) {
+	if m.Status.Deprecated == nil {
+		m.Status.Deprecated = &IonosCloudMachineDeprecatedStatus{}
+	}
+	if m.Status.Deprecated.V1Beta1 == nil {
+		m.Status.Deprecated.V1Beta1 = &IonosCloudMachineV1Beta1DeprecatedStatus{}
+	}
+	m.Status.Deprecated.V1Beta1.Ready = ready //nolint:staticcheck // Intentionally setting deprecated field.
+}
+
 // GetConditions returns the v1beta2 conditions from status.conditions.
 func (m *IonosCloudMachine) GetConditions() []metav1.Condition {
 	return m.Status.Conditions

--- a/internal/service/cloud/server.go
+++ b/internal/service/cloud/server.go
@@ -147,13 +147,7 @@ func (s *Service) ReconcileServerDeletion(ctx context.Context, ms *scope.Machine
 func (*Service) FinalizeMachineProvisioning(_ context.Context, ms *scope.Machine) (bool, error) {
 	ms.IonosMachine.Status.Initialization.Provisioned = new(true)
 	// Set deprecated v1beta1 ready field for backwards compatibility.
-	if ms.IonosMachine.Status.Deprecated == nil {
-		ms.IonosMachine.Status.Deprecated = &infrav1.IonosCloudMachineDeprecatedStatus{}
-	}
-	if ms.IonosMachine.Status.Deprecated.V1Beta1 == nil {
-		ms.IonosMachine.Status.Deprecated.V1Beta1 = &infrav1.IonosCloudMachineV1Beta1DeprecatedStatus{}
-	}
-	ms.IonosMachine.Status.Deprecated.V1Beta1.Ready = true //nolint:staticcheck // Intentionally setting deprecated field for v1beta1 backwards compatibility.
+	ms.IonosMachine.SetV1Beta1Ready(true) //nolint:staticcheck // Intentionally setting deprecated field for v1beta1 backwards compatibility.
 	conditions.Set(ms.IonosMachine, metav1.Condition{
 		Type:   string(infrav1.MachineProvisionedCondition),
 		Status: metav1.ConditionTrue,


### PR DESCRIPTION
## Summary

- Adds `SetV1Beta1Ready(bool)` method to `IonosCloudMachine` in `api/v1alpha1/ionoscloudmachine_types.go`, following the same nil-safe two-step initialization pattern as the existing `SetV1Beta1Conditions`
- Replaces three inline nil-guard lines in `FinalizeMachineProvisioning` (`server.go`) with a single `ms.IonosMachine.SetV1Beta1Ready(true)` call
- Eliminates the duplicated maintenance surface: any future field added to `IonosCloudMachineDeprecatedStatus` no longer requires a matching update in the inline copy

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Review that `SetV1Beta1Ready` mirrors `SetV1Beta1Conditions` nil-safe pattern exactly
- [ ] Review that `FinalizeMachineProvisioning` no longer references `infrav1.IonosCloudMachineDeprecatedStatus` or `infrav1.IonosCloudMachineV1Beta1DeprecatedStatus` directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)