### PR TITLE
fix: increase wait period for IONOS resources to become stable

### DIFF
--- a/test/e2e/config/ionoscloud.yaml
+++ b/test/e2e/config/ionoscloud.yaml
@@ -94,6 +94,7 @@ intervals:
   default/wait-worker-nodes: [ "30m", "10s" ]
   default/wait-delete-cluster: [ "30m", "10s" ]
   default/wait-nodes-ready: ["30m", "10s"]
+  default/wait-resource-versions-become-stable: ["5m", "10s"]
   scale/wait-cluster: ["30m", "10s"]
   scale/wait-control-plane: ["30m", "10s"]
   scale/wait-worker-nodes: ["30m", "10s"]


### PR DESCRIPTION
**What is the purpose of this pull request/Why do we need it?**\
e2e tests are [failing](https://github.com/ionos-cloud/cluster-api-provider-ionoscloud/actions/runs/31574491883/job/94043443500#step:5:3650) during `Check resourceVersions remain stable` step. There is a cluster of issues related to this check in [capi](https://github.com/kubernetes-sigs/cluster-api/issues?q=is%3Aissue%20ValidateResourceVersionStable). One fix has [landed in 1.11](https://github.com/kubernetes-sigs/cluster-api/pull/13331), but from the subsequent issues it looks like it was not enough. [A subsequent change](https://github.com/kubernetes-sigs/cluster-api/pull/13882/changes) doubled the interval.

This PR increases resource version become stable interval from standard 2m15s to 5m10s.

**Issue #, if available:**

**Description of changes:**
Increases time period to wait until resources become stable.

**Special notes for your reviewer:**

**Checklist:**
- [ ] Documentation updated
- [ ] Unit Tests added
- [ ] E2E Tests added
- [ ] Includes [emojis](https://github.com/kubernetes-sigs/kubebuilder-release-tools?tab=readme-ov-file#kubebuilder-project-versioning)